### PR TITLE
fixed bug in regex of TransactionDetails

### DIFF
--- a/mt940/tags.py
+++ b/mt940/tags.py
@@ -189,7 +189,7 @@ class TransactionDetails(Tag):
     '''
     id = 86
     scope = mt940.models.Transaction
-    pattern = r'(?P<transaction_details>[.\s]{0,330})'
+    pattern = r'(?P<transaction_details>.{0,330})'
 
 
 @enum.unique

--- a/mt940/tags.py
+++ b/mt940/tags.py
@@ -189,7 +189,7 @@ class TransactionDetails(Tag):
     '''
     id = 86
     scope = mt940.models.Transaction
-    pattern = r'(?P<transaction_details>.{0,330})'
+    pattern = r'(?P<transaction_details>[\s\S]{0,330})'
 
 
 @enum.unique


### PR DESCRIPTION
The existing regex in TransactionDetails doesn't actually capture anything. See original regex here:

https://regex101.com/r/cH0hG2/1

And the replacement:

https://regex101.com/r/xX4oI0/1

It captures any character(s) (up to 330), which I thought was the original intent. 