### PR TITLE
Fix parser tests always succeeding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,8 @@ pip-log.txt
 .tox
 nosetests.xml
 cover
+/.cache/
+/htmlcov/
 
 # Translations
 *.mo
@@ -44,4 +46,3 @@ output/*/index.html
 docs/_build
 /docs/doctrees/
 /docs/html/
-/docs/doctrees/

--- a/tests/test_sta_parsing.py
+++ b/tests/test_sta_parsing.py
@@ -65,7 +65,7 @@ def compare(a, b, key=''):
 @pytest.mark.parametrize('sta_file', get_sta_files())
 def test_parse(sta_file):
     transactions = mt940.parse(sta_file)
-    write_yaml_data(sta_file, transactions)
+    # write_yaml_data(sta_file, transactions)
     expected = get_yaml_data(sta_file)
 
     assert len(transactions) >= 0


### PR DESCRIPTION
I think the yaml writer line was accidently left in. Parser output is compared to basically itself, written to yaml right before. I ran a few mutations, you can break quite a lot with the tests being none the wiser.