### PR TITLE
fix for future transactions from Fiducia (e.g. Volksbank Ortenau)

### DIFF
--- a/mt940/tags.py
+++ b/mt940/tags.py
@@ -174,7 +174,7 @@ class FloorLimitIndicator(Tag):
     id = 34
     pattern = r'''^
     (?P<currency>[A-Z]{3})  # 3!a Currency
-    (?P<status>[DC]?)  # 2a Debit/Credit Mark
+    (?P<status>[DC ]?)  # 2a Debit/Credit Mark
     (?P<amount>[0-9,]{0,16})  # 15d Amount (includes decimal sign, so 16)
     $'''
 
@@ -353,7 +353,7 @@ class SumEntries(Tag):
 
     id = 90
     pattern = r'''^
-    (?P<number>\d+)
+    (?P<number>\d*)
     (?P<currency>.{3})  # 3!a Currency
     (?P<amount>[\d,]{1,15})  # 15d Amount
     '''


### PR DESCRIPTION
relaxed regexes:

```python
matching (19) "EUR 999999999999,99" against "^
    (?P<currency>[A-Z]{3})  # 3!a Currency
    (?P<status>[DC]?)  # 2a Debit/Credit Mark
    (?P<amount>[0-9,]{0,16})  # 15d Amount (includes decimal sign, so 16)
    $"
no match for "    $" against " 999999999999,99"
Traceback (most recent call last):
  File "./client.py", line 39, in <module>
    statement = f.get_statement(a, date.today() - timedelta(days), date.today())
  File "/usr/local/lib/python3.6/site-packages/fints/client.py", line 89, in get_statement
    statement += mt940_to_array(m.group(2))
  File "/usr/local/lib/python3.6/site-packages/fints/utils.py", line 11, in mt940_to_array
    return transactions.parse(data)
  File "/usr/local/lib/python3.6/site-packages/mt940/models.py", line 407, in parse
    tag_dict = tag.parse(self, tag_data)
  File "/usr/local/lib/python3.6/site-packages/mt940/tags.py", line 84, in parse
    self, value)
RuntimeError: ('Unable to parse "<mt940.tags.FloorLimitIndicator object at 0x7f55f5d01b70>" from "EUR 999999999999,99"', <mt940.tags.FloorLimitIndicator object at 0x7f55f5d01b70>, 'EUR 999999999999,99')

matching (6) "EUR,00" against "^
    (?P<number>\d+)
    (?P<currency>.{3})  # 3!a Currency
    (?P<amount>[\d,]{1,15})  # 15d Amount
    "
no match for "    (?P<number>\d+)" against "EUR,00"
Traceback (most recent call last):
  File "./client.py", line 39, in <module>
    statement = f.get_statement(a, date.today() - timedelta(days), date.today())
  File "/usr/local/lib/python3.6/site-packages/fints/client.py", line 89, in get_statement
    statement += mt940_to_array(m.group(2))
  File "/usr/local/lib/python3.6/site-packages/fints/utils.py", line 11, in mt940_to_array
    return transactions.parse(data)
  File "/usr/local/lib/python3.6/site-packages/mt940/models.py", line 407, in parse
    tag_dict = tag.parse(self, tag_data)
  File "/usr/local/lib/python3.6/site-packages/mt940/tags.py", line 84, in parse
    self, value)
RuntimeError: ('Unable to parse "<mt940.tags.SumCreditEntries object at 0x7fbb344065c0>" from "EUR,00"', <mt940.tags.SumCreditEntries object at 0x7fbb344065c0>, 'EUR,00')
```