### PR TITLE
Fix entry_date for transactions booked in the next year

### DIFF
--- a/mt940/tags.py
+++ b/mt940/tags.py
@@ -306,11 +306,18 @@ class Statement(Tag):
         data['date'] = models.Date(**data)
 
         if data.get('entry_day') and data.get('entry_month'):
-            data['entry_date'] = models.Date(
+            entry_date = models.Date(
                 day=data.get('entry_day'),
                 month=data.get('entry_month'),
                 year=str(data['date'].year),
             )
+            if entry_date.month == 1 and data['date'].month == 12:
+                entry_date = models.Date(
+                    day=str(entry_date.day),
+                    month=str(entry_date.month),
+                    year=str(entry_date.year + 1),
+                )
+            data['entry_date'] = entry_date
         return data
 
 


### PR DESCRIPTION
when entry_month is 1, and month is 12, we must assume that the
transaction was booked in the next year.

Fixes #17.