### PR TITLE
Fix the issue with funds code when it ends on "D"

### DIFF
--- a/mt940/tags.py
+++ b/mt940/tags.py
@@ -295,7 +295,7 @@ class Statement(Tag):
     (?P<day>\d{2})
     (?P<entry_month>\d{2})?  # [4!n] Entry Date (MMDD)
     (?P<entry_day>\d{2})?
-    (?P<status>[A-Z]?[DC])  # 2a Debit/Credit Mark
+    (?P<status>R?[DC])  # 2a Debit/Credit Mark
     (?P<funds_code>[A-Z])? # [1!a] Funds Code (3rd character of the currency
                             # code, if needed)
     \n? # apparently some banks (sparkassen) incorporate newlines here
@@ -462,6 +462,3 @@ class Tags(enum.Enum):
 
 
 TAG_BY_ID = {t.value.id: t.value for t in Tags}
-
-
-


### PR DESCRIPTION
According to all documentations, the Debit/Credit mark can be:
- "D" for Debit
- "C" for Credit
- "RD" for Reversal Debit
- "RC" for Reversal Credit

Fixes #90