### PR TITLE
Fix issue with customer/bank references parsing

### DIFF
--- a/mt940/tags.py
+++ b/mt940/tags.py
@@ -301,7 +301,7 @@ class Statement(Tag):
     \n? # apparently some banks (sparkassen) incorporate newlines here
     (?P<amount>[\d,]{1,15})  # 15d Amount
     (?P<id>[A-Z][A-Z0-9 ]{3})?  # 1!a3!c Transaction Type Identification Code
-    (?P<customer_reference>.{0,16})  # 16x Customer Reference
+    (?P<customer_reference>[^/\n]{0,16})  # 16x Customer Reference
     (//(?P<bank_reference>.{0,23}))?  # [//23x] Bank Reference
     (\n?(?P<extra_details>.{0,34}))?  # [34x] Supplementary Details
     $'''
@@ -462,6 +462,3 @@ class Tags(enum.Enum):
 
 
 TAG_BY_ID = {t.value.id: t.value for t in Tags}
-
-
-


### PR DESCRIPTION
Fix the issue for the statement like this:

```
2001010101DR12,34FCHGTRF SVC//200101ZCPB123456
Some information here
```

NOTE: avoid newline is needed because "." character is any symbol except line terminators, when we use "[^...]" notation, line terminators are included in the match.

Fixes #96