### PR TITLE
unsupported operand type 'Nonetype' and 'str'

### DIFF
--- a/mt940/models.py
+++ b/mt940/models.py
@@ -503,7 +503,10 @@ class Transactions(Sequence[Transaction]):
         transaction = self.transactions[-1]
         for k, v in result.items():
             if k in transaction.data and hasattr(v, 'strip'):
-                transaction.data[k] += f'\n{v.strip()}'
+                if transaction.data[k] is None:
+                    transaction.data[k] = v.strip()
+                else:
+                    transaction.data[k] += '\n%s' % v.strip()
             else:
                 transaction.data[k] = v
 


### PR DESCRIPTION
Fix TypeError when appending to NoneType in transaction data

This PR fixes a TypeError that occurs when attempting to append a string to a NoneType value in transaction.data. The issue arises because some keys in transaction.data are initialized as None, leading to an unsupported operation (NoneType += str).

The solution ensures that if transaction.data[k] is None, it is first assigned the stripped value of v, preventing the error. Otherwise, the existing behavior of appending the new value with a newline separator is maintained.