### PR TITLE
Fix issue #109: Remove trailing BIC text from purpose field

### DIFF
--- a/mt940/processors.py
+++ b/mt940/processors.py
@@ -359,7 +359,12 @@ def transaction_details_post_processor(
 
         if purpose and any(gvk in purpose for gvk in GVC_KEYS if gvk != ''):
             result.update(_parse_mt940_gvcodes(result['purpose']))
-
+            
+        # Clean up the purpose field
+        if result.get('purpose'):
+            # Remove trailing "BIC" without the actual BIC value
+            result['purpose'] = re.sub(r' BIC$', '', result['purpose'])
+            
         del result['transaction_details']
 
     return result

--- a/mt940/processors.py
+++ b/mt940/processors.py
@@ -362,7 +362,7 @@ def transaction_details_post_processor(
             
         # Clean up the purpose field
         if result.get('purpose'):
-            # Remove trailing "BIC" without the actual BIC value
+            # Remove trailing "BIC" without an actual BIC value
             result['purpose'] = re.sub(r' BIC$', '', result['purpose'])
             
         del result['transaction_details']

--- a/mt940_tests/test_issues/__init__.py
+++ b/mt940_tests/test_issues/__init__.py
@@ -1,0 +1,1 @@
+# This file is intentionally left empty to make the directory a proper package

--- a/mt940_tests/test_issues/test_purpose_field_formatting.py
+++ b/mt940_tests/test_issues/test_purpose_field_formatting.py
@@ -1,0 +1,34 @@
+import unittest
+
+import mt940
+
+
+class TestPurposeFieldFormatting(unittest.TestCase):
+    """Test for purpose field formatting in MT940 statements."""
+
+    def test_purpose_field_formatting(self):
+        """Test that the purpose field is correctly formatted."""
+        # Parse the example from the issue #109
+        trans = mt940.parse("""\
+:61:2401231020DR30,00NDDTKREF+
+:86:105?00Basislastschrift?10931?20EREF+DD-1-23.01.2024
+?21KREF+20241022098765432109 00?22000000000237?23MREF+27
+?24CRED+DE47ZZZ00012345678?25SVWZ+Mitgliedsbeitrag
+?26Mein Verein EREF: D?27D-1-23.01.2024 MREF: 27 CRE
+?28D: DE47ZZZ00012345678 IBAN:?29 DE69280123450012345670 BIC
+?30GENODEF1WDH?31DE69280123450012345670
+?32Mein Verein e.V.?34992?60: GENODEF1WDH
+""")
+
+        # Get the purpose field
+        purpose = trans[0].data.get('purpose', '')
+
+        # Check that the purpose field doesn't end with "BIC"
+        self.assertFalse(purpose.endswith(' BIC'))
+
+        # Check that the purpose field contains the IBAN
+        self.assertTrue('DE69280123450012345670' in purpose)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This PR fixes issue #109 by removing trailing BIC text from the purpose field when it appears without an actual BIC value.

The fix is implemented in the `transaction_details_post_processor` function in `processors.py` by adding a regular expression replacement that removes the trailing " BIC" text when it appears at the end of the purpose field.

A test case has been added to verify the fix.