### PR TITLE
Update tags.py

### DIFF
--- a/mt940/tags.py
+++ b/mt940/tags.py
@@ -110,7 +110,7 @@ class Tag:
         :return: A dictionary of matched group values.
         :raises RuntimeError: If parsing fails.
         """
-        match = self.re.match(value)
+        match = re.match(self.pattern, value, self.RE_FLAGS)
         if match:  # pragma: no branch
             self.logger.debug(
                 'matched (%d) %r against "%s", got: %s',


### PR DESCRIPTION
# Remove precompiled regex pattern

## Change
Changed the way regex pattern is used:
- Old code: `match = self.re.match(value)` (used precompiled pattern)
- New code: `match = re.match(self.pattern, value, self.RE_FLAGS)` (uses pattern string directly)

## Why
- Old code used a precompiled regex pattern (`self.re`)
- This prevented runtime pattern modification (`pattern`) since the compiled version remained unchanged
- MT940 parser needs the ability to modify patterns at runtime

## Impact
- Pattern can now be changed dynamically
- Provides more flexibility when parsing rules need to be modified
- Small performance trade-off (pattern is compiled on each execution)

## Technical Details
- Removed dependency on precompiled regex object
- Pattern is now interpreted on each `parse()` call

## Testing
✅ Existing tests pass
✅ New tests needed to verify runtime pattern modification