### PR TITLE
Triage open/closed issues: parser fixes + opt-in transaction grouping

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,26 @@ trs.parse(ASNB_mt940_data())
 print(pprint.pformat(trs.data, sort_dicts=False))
 ```
 
+### Transaction grouping (opt-in)
+
+By default a new transaction is started only on the `:61:` statement tag.
+Some banks delimit transactions differently — for example by repeating the
+`:20:` transaction reference per block. Because changing the default grouping
+would break existing users, this behaviour is **opt-in**: pass
+`transaction_boundary` (an iterable of tag *slugs*) to start a new transaction
+on those tags too. Omitting it preserves the historical behaviour.
+
+```python
+import mt940
+
+# Each `:20:` (transaction_reference_number) starts its own transaction:
+transactions = mt940.parse(
+    data, transaction_boundary={'transaction_reference_number'}
+)
+```
+
+The same option is accepted by `mt940.models.Transactions(transaction_boundary=...)`.
+
 ## Contributing
 
 Help is greatly appreciated. Please clone the **develop** branch and run `tox`

--- a/README.md
+++ b/README.md
@@ -115,6 +115,23 @@ transactions = mt940.parse(
 
 The same option is accepted by `mt940.models.Transactions(transaction_boundary=...)`.
 
+### Banks with longer reference fields (opt-in)
+
+Some banks (e.g. GLS / Atruvia) put a customer reference longer than the SWIFT
+16-character cap on the `:61:` line, followed by the `//` bank reference.
+Relaxing the default would change how other banks (e.g. Rabobank) split
+same-line data, so this is handled by an **opt-in** `StatementGLS` tag:
+
+```python
+import mt940
+
+gls = mt940.tags.StatementGLS()
+transactions = mt940.parse(data, tags={gls.id: gls})
+```
+
+(Longer *supplementary details* — issue #117, e.g. Wise — are handled by the
+default parser and need no opt-in.)
+
 ## Contributing
 
 Help is greatly appreciated. Please clone the **develop** branch and run `tox`

--- a/mt940/models.py
+++ b/mt940/models.py
@@ -498,15 +498,17 @@ class Transactions(Sequence[Transaction]):
         for processor in self.processors.get(f'post_{tag.slug}', []):
             result = processor(self, tag, tag_dict, result)
 
-        if tag.slug in self.transaction_boundary:
+        if isinstance(tag, mt940.tags.Statement):
+            # Statement (:61:) handling always takes precedence so it cannot
+            # be bypassed by listing its slug in transaction_boundary.
+            self._process_statement_tag(result)
+        elif tag.slug in self.transaction_boundary:
             # Opt-in (issue #110): this tag opens a new transaction block.
             self.transactions.append(Transaction(self, result))
             if issubclass(tag.scope, Transactions):
                 # Keep statement-level data (e.g. the :20: reference) global
                 # too, so later :61: tags in the same block can copy it.
                 self.data.update(result)
-        elif isinstance(tag, mt940.tags.Statement):
-            self._process_statement_tag(result)
         elif issubclass(tag.scope, Transaction) and self.transactions:
             self._update_transaction(result)
         elif issubclass(  # pragma: no branch

--- a/mt940/models.py
+++ b/mt940/models.py
@@ -388,6 +388,10 @@ class Transactions(Sequence[Transaction]):
         # `:61:` statement tag starts a transaction. Passing e.g.
         # ``{'transaction_reference_number'}`` makes each `:20:` start its own
         # transaction too. Empty (the default) preserves the legacy behaviour.
+        if isinstance(transaction_boundary, str):
+            # A bare string is almost certainly a single slug, not an iterable
+            # of single characters.
+            transaction_boundary = (transaction_boundary,)
         self.transaction_boundary: frozenset[str] = frozenset(
             transaction_boundary or ()
         )
@@ -497,6 +501,10 @@ class Transactions(Sequence[Transaction]):
         if tag.slug in self.transaction_boundary:
             # Opt-in (issue #110): this tag opens a new transaction block.
             self.transactions.append(Transaction(self, result))
+            if issubclass(tag.scope, Transactions):
+                # Keep statement-level data (e.g. the :20: reference) global
+                # too, so later :61: tags in the same block can copy it.
+                self.data.update(result)
         elif isinstance(tag, mt940.tags.Statement):
             self._process_statement_tag(result)
         elif issubclass(tag.scope, Transaction) and self.transactions:

--- a/mt940/models.py
+++ b/mt940/models.py
@@ -5,7 +5,13 @@ import decimal
 import re
 import typing
 import warnings
-from collections.abc import Callable, Mapping, MutableMapping, Sequence
+from collections.abc import (
+    Callable,
+    Iterable,
+    Mapping,
+    MutableMapping,
+    Sequence,
+)
 from typing import Any, ClassVar, overload
 
 import mt940
@@ -363,6 +369,7 @@ class Transactions(Sequence[Transaction]):
         self,
         processors: dict[str, list[Callable[..., Any]]] | None = None,
         tags: dict[int | str, mt940.tags.Tag] | None = None,
+        transaction_boundary: Iterable[str] | None = None,
     ) -> None:
         self.processors: dict[str, list[Callable[..., Any]]] = (
             self.DEFAULT_PROCESSORS.copy()
@@ -375,6 +382,15 @@ class Transactions(Sequence[Transaction]):
             self.processors.update(processors)
         if tags:
             self.tags.update(tags)
+
+        # Opt-in (issue #110): tag slugs that each open a new transaction.
+        # Banks differ in how they delimit transactions; by default only the
+        # `:61:` statement tag starts a transaction. Passing e.g.
+        # ``{'transaction_reference_number'}`` makes each `:20:` start its own
+        # transaction too. Empty (the default) preserves the legacy behaviour.
+        self.transaction_boundary: frozenset[str] = frozenset(
+            transaction_boundary or ()
+        )
 
         self.transactions: list[Transaction] = []
         self.data: dict[str, Any] = {}
@@ -478,7 +494,10 @@ class Transactions(Sequence[Transaction]):
         for processor in self.processors.get(f'post_{tag.slug}', []):
             result = processor(self, tag, tag_dict, result)
 
-        if isinstance(tag, mt940.tags.Statement):
+        if tag.slug in self.transaction_boundary:
+            # Opt-in (issue #110): this tag opens a new transaction block.
+            self.transactions.append(Transaction(self, result))
+        elif isinstance(tag, mt940.tags.Statement):
             self._process_statement_tag(result)
         elif issubclass(tag.scope, Transaction) and self.transactions:
             self._update_transaction(result)

--- a/mt940/parser.py
+++ b/mt940/parser.py
@@ -40,11 +40,19 @@ def parse(
     encoding: str | None = None,
     processors: dict[str, list[Any]] | None = None,
     tags: dict[Any, Any] | None = None,
+    transaction_boundary: Any = None,
 ) -> Transactions:
     """
     Parses mt940 data and returns transactions object
 
     :param src: file handler to read, filename to read or raw data as string
+    :param encoding: optional encoding override for byte input
+    :param processors: optional extra pre/post processors
+    :param tags: optional extra/override tag parsers
+    :param transaction_boundary: optional iterable of tag *slugs* that each
+        start a new transaction (issue #110). By default only ``:61:`` starts a
+        transaction; pass e.g. ``{'transaction_reference_number'}`` to also
+        start one on every ``:20:``. Omitting it keeps the legacy behaviour.
     :return: Collection of transactions
     :rtype: Transactions
     """
@@ -83,7 +91,9 @@ def parse(
             raise exception  # pragma: no cover
 
     assert isinstance(data, str)
-    transactions = mt940.models.Transactions(processors, tags)
+    transactions = mt940.models.Transactions(
+        processors, tags, transaction_boundary=transaction_boundary
+    )
     transactions.parse(data)
 
     return transactions

--- a/mt940/processors.py
+++ b/mt940/processors.py
@@ -278,12 +278,16 @@ def _process_segments(
             key32 = DETAIL_KEYS['32']
             result[key32].append(value)
         elif key.startswith('2'):
-            # For segment keys beginning with '2', adjust specific
-            # segments by trimming trailing identifiers.
-            if key == '29' and value.endswith(' BIC'):
-                value = value.removesuffix(' BIC').rstrip()
-            elif key == '28D' and value.endswith(' IBAN'):
-                value = value.removesuffix(' IBAN').rstrip()
+            # Some banks append a bare ' BIC'/' IBAN' label with no value at
+            # the end of a detail segment (issue #109); strip the dangling
+            # label so it does not pollute the purpose. Segment keys are
+            # always two characters (see _parse_segments), so the historical
+            # '29'/'28D' key checks could never match the IBAN case -- the
+            # label is matched on the value instead.
+            for label in (' BIC', ' IBAN'):
+                if value.endswith(label):
+                    value = value.removesuffix(label).rstrip()
+                    break
             key20 = DETAIL_KEYS['20']
             result[key20].append(value)
         elif key in {'60', '61', '62', '63', '64', '65'}:

--- a/mt940/tags.py
+++ b/mt940/tags.py
@@ -419,9 +419,16 @@ class Statement(Tag):
     [\n ]?
     (?P<amount>[\d,]{1,15})  # 15d Amount
     (?P<id>[A-Z][A-Z0-9 ]{3})?
-    (?P<customer_reference>((?!//)[^\n]){0,16})
+    # Customer reference: the SWIFT spec caps this at 16x. Several banks
+    # (e.g. GLS / Atruvia, issue #111) send longer references followed by the
+    # // bank-reference delimiter, so when a // is present we capture up to it;
+    # otherwise we keep the 16x cap so banks that pack extra data on the same
+    # line (e.g. Rabobank) keep splitting it into extra_details as before.
+    (?P<customer_reference>(?:(?!//)[^\n])*(?=//)|(?:(?!//)[^\n]){0,16})
     (//(?P<bank_reference>.{0,23}))?
-    (\n?(?P<extra_details>.{0,34}))?
+    # Supplementary details: spec caps this at 34x, but some banks (e.g. Wise,
+    # issue #117) send longer, so the length limit is relaxed.
+    (\n?(?P<extra_details>.*))?
     $"""
 
     def __call__(
@@ -436,7 +443,7 @@ class Statement(Tag):
         entry_month = str(data.get('entry_month') or '')
 
         if entry_day.isdigit() and entry_month.isdigit():
-            entry_date = data['entry_date'] = models.Date(
+            entry_date = models.Date(
                 day=entry_day, month=entry_month, year=str(date.year)
             )
             if date > entry_date and (date - entry_date).days >= 330:
@@ -446,11 +453,18 @@ class Statement(Tag):
             else:
                 year = 0
 
-            data['guessed_entry_date'] = models.Date(
-                day=entry_date.day,
-                month=entry_date.month,
-                year=entry_date.year + year,
-            )
+            # Correct the entry date's year when the entry date crosses a
+            # year boundary relative to the value date (issue #121). Both
+            # `entry_date` and `guessed_entry_date` expose the resolved value;
+            # `guessed_entry_date` is kept as a backwards-compatible alias.
+            if year:
+                entry_date = models.Date(
+                    day=entry_date.day,
+                    month=entry_date.month,
+                    year=entry_date.year + year,
+                )
+            data['entry_date'] = entry_date
+            data['guessed_entry_date'] = entry_date
 
         return data
 

--- a/mt940/tags.py
+++ b/mt940/tags.py
@@ -419,15 +419,11 @@ class Statement(Tag):
     [\n ]?
     (?P<amount>[\d,]{1,15})  # 15d Amount
     (?P<id>[A-Z][A-Z0-9 ]{3})?
-    # Customer reference: the SWIFT spec caps this at 16x. Several banks
-    # (e.g. GLS / Atruvia, issue #111) send longer references followed by the
-    # // bank-reference delimiter, so when a // is present we capture up to it;
-    # otherwise we keep the 16x cap so banks that pack extra data on the same
-    # line (e.g. Rabobank) keep splitting it into extra_details as before.
-    (?P<customer_reference>(?:(?!//)[^\n])*(?=//)|(?:(?!//)[^\n]){0,16})
+    (?P<customer_reference>((?!//)[^\n]){0,16})
     (//(?P<bank_reference>.{0,23}))?
-    # Supplementary details: spec caps this at 34x, but some banks (e.g. Wise,
-    # issue #117) send longer, so the length limit is relaxed.
+    # Supplementary details: the SWIFT spec caps this at 34x, but some banks
+    # (e.g. Wise, issue #117) send more, so the length limit is relaxed. This
+    # only ever turns a previous parse error into a successful parse.
     (\n?(?P<extra_details>.*))?
     $"""
 
@@ -506,6 +502,41 @@ class StatementASNB(Statement):
         self, transactions: models.Transactions, value: dict[str, typing.Any]
     ) -> dict[str, object]:
         return super().__call__(transactions, value)
+
+
+class StatementGLS(Statement):
+    """Statement variant for GLS / Atruvia banks (issue #111).
+
+    These banks send a customer reference longer than the SWIFT 16x cap,
+    followed by the ``//`` bank-reference delimiter (e.g.
+    ``...DR20,NTRFBIPI-dvT1FzfMqvzF5HaU4oetlH7SGRkonU//2022070616391534000``).
+
+    This is an opt-in tag because relaxing the default customer-reference
+    length would change how banks that legitimately pack data after a 16x
+    reference (e.g. Rabobank) are parsed. Enable it explicitly::
+
+        import mt940
+
+        gls = mt940.tags.StatementGLS()
+        mt940.parse(data, tags={gls.id: gls})
+    """
+
+    pattern = r"""^
+    (?P<year>\d{2})  # 6!n Value Date (YYMMDD)
+    (?P<month>\d{2})
+    (?P<day>\d{2})
+    (?P<entry_month>\d{2}|\s{2})?  # [4!n] Entry Date (MMDD)
+    (?P<entry_day>\d{2}|\s{2})?
+    (?P<status>R?[DC])  # 2a Debit/Credit Mark
+    (?P<funds_code>[A-Z])?
+    [\n ]?
+    (?P<amount>[\d,]{1,15})  # 15d Amount
+    (?P<id>[A-Z][A-Z0-9 ]{3})?
+    # Customer reference of any length, up to the // bank reference.
+    (?P<customer_reference>(?:(?!//)[^\n])*)
+    (//(?P<bank_reference>.{0,23}))?
+    (\n?(?P<extra_details>.*))?
+    $"""
 
 
 class ClosingBalance(BalanceBase):

--- a/mt940_tests/test_entry_dates.py
+++ b/mt940_tests/test_entry_dates.py
@@ -1,44 +1,46 @@
+import datetime
+
 import mt940
+
+
+def _statement(
+    transactions: mt940.models.Transactions, **kwargs: object
+) -> dict:
+    statement = mt940.tags.Statement()
+    data = dict(amount='123', status='D', **kwargs)
+    return statement(transactions, data)
 
 
 def test_entry_dates_wrapping_years():
     transactions = mt940.models.Transactions()
-    statement = mt940.tags.Statement()
-    data = dict(
-        amount='123',
-        status='D',
-        year=2000,
-    )
 
-    # Regular statement
-    statement(
-        transactions,
-        dict(
-            data.items(),
-            month=1,
-            day=1,
-        ),
-    )
+    # Regular statement without an entry date: only the value date is set.
+    regular = _statement(transactions, year=2000, month=1, day=1)
+    assert regular['date'] == datetime.date(2000, 1, 1)
+    assert 'entry_date' not in regular
 
-    # Statement which wraps to the future
-    statement(
-        transactions,
-        dict(
-            data.items(),
-            month=12,
-            day=31,
-            entry_day=1,
-            entry_month=1,
-        ),
+    # Entry date in the same year as the value date: no correction applied.
+    same_year = _statement(
+        transactions, year=2000, month=6, day=15, entry_month=6, entry_day=10
     )
-    # Statement which wraps the past year
-    statement(
-        transactions,
-        dict(
-            data.items(),
-            month=1,
-            day=1,
-            entry_day=31,
-            entry_month=12,
-        ),
+    assert same_year['date'] == datetime.date(2000, 6, 15)
+    assert same_year['entry_date'] == datetime.date(2000, 6, 10)
+    assert same_year['guessed_entry_date'] == same_year['entry_date']
+
+    # Entry date wraps into the next year (value date Dec, entry date Jan).
+    forward = _statement(
+        transactions, year=2000, month=12, day=31, entry_month=1, entry_day=1
     )
+    assert forward['date'] == datetime.date(2000, 12, 31)
+    assert forward['entry_date'] == datetime.date(2001, 1, 1)
+    assert forward['guessed_entry_date'] == forward['entry_date']
+
+    # Entry date wraps into the previous year (value date Jan, entry date
+    # Dec) -- issue #121. `entry_date` must be resolved, not left in the
+    # value date's year.
+    backward = _statement(
+        transactions, year=2000, month=1, day=1, entry_month=12, entry_day=31
+    )
+    assert backward['date'] == datetime.date(2000, 1, 1)
+    assert backward['entry_date'] == datetime.date(1999, 12, 31)
+    assert backward['guessed_entry_date'] == backward['entry_date']

--- a/mt940_tests/test_issues/test_issue106_streams.py
+++ b/mt940_tests/test_issues/test_issue106_streams.py
@@ -1,0 +1,26 @@
+"""Issue #106: parsing must not depend on sys.stdout/sys.stderr being usable.
+
+Sandboxed / serverless environments (and some GUI apps) run with
+``sys.stdout``/``sys.stderr`` set to ``None``. Parsing valid data must work
+there without raising ``AttributeError: 'NoneType' object has no attribute
+'encoding'``.
+"""
+
+import mt940
+
+VALID = """:20:STARTUMS
+:25:NL12RABO0123456789
+:28C:0
+:60F:C220706EUR100,00
+:61:2207060706C10,00NTRFref//bank
+:86:116?00Payment
+:62F:C220706EUR110,00
+"""
+
+
+def test_parses_without_stdout_and_stderr(monkeypatch):
+    monkeypatch.setattr('sys.stdout', None)
+    monkeypatch.setattr('sys.stderr', None)
+    transactions = mt940.parse(VALID)
+    assert len(transactions) == 1
+    assert str(transactions[0].data['amount']) == '10.00 EUR'

--- a/mt940_tests/test_issues/test_issue110_boundary.py
+++ b/mt940_tests/test_issues/test_issue110_boundary.py
@@ -41,3 +41,49 @@ def test_transaction_boundary_opt_in_via_transactions():
     )
     transactions.parse(DATA)
     assert len(transactions) == 2
+
+
+def test_transaction_boundary_accepts_a_bare_string():
+    # A single slug passed as a plain string must not be iterated per-char.
+    transactions = mt940.parse(
+        DATA, transaction_boundary='transaction_reference_number'
+    )
+    refs = [t.data.get('transaction_reference') for t in transactions]
+    assert refs == ['REF1', 'REF2']
+
+
+def test_reference_propagates_to_later_statements_in_block():
+    # A block with one :20: and several :61: tags: every transaction in the
+    # block must carry the block's reference (the global reference is kept in
+    # sync for the transactions_to_transaction post-processor).
+    data = """:20:REF1
+:61:2001010101C5,00NTRFa//b
+:86:116?00p1
+:61:2001020102C6,00NTRFc//d
+:86:116?00p2
+:20:REF2
+:61:2001030103C7,00NTRFe//f
+:62F:C200101EUR18,00
+"""
+    transactions = mt940.parse(
+        data, transaction_boundary={'transaction_reference_number'}
+    )
+    refs = [t.data.get('transaction_reference') for t in transactions]
+    assert refs == ['REF1', 'REF1', 'REF2']
+
+
+def test_transaction_scoped_boundary_tag():
+    # A boundary tag whose scope is Transaction (not Transactions) opens a new
+    # transaction without touching the global statement data.
+    data = """:20:REF
+:25:ACC
+:60F:C200101EUR0,00
+:61:2001010101C5,00NTRFa//b
+:86:116?00detail
+:62F:C200101EUR5,00
+"""
+    transactions = mt940.parse(
+        data, transaction_boundary={'transaction_details'}
+    )
+    # The :86: detail tag now opens its own transaction.
+    assert len(transactions) == 2

--- a/mt940_tests/test_issues/test_issue110_boundary.py
+++ b/mt940_tests/test_issues/test_issue110_boundary.py
@@ -1,0 +1,43 @@
+"""Issue #110: opt-in transaction boundaries.
+
+By default only the ``:61:`` statement tag starts a new transaction, so a
+statement that repeats the ``:20:`` transaction reference per block collapses
+into a single transaction (legacy behaviour, kept for backwards
+compatibility). The opt-in ``transaction_boundary`` option lets callers
+nominate extra tag slugs that each open a new transaction.
+"""
+
+import mt940
+
+DATA = """:20:REF1
+:20:REF2
+:25:ACC
+:60F:C200101EUR0,00
+:61:2001010101C5,00NTRFr//b
+:86:116?00p
+:62F:C200101EUR5,00
+"""
+
+
+def test_default_grouping_unchanged():
+    # Legacy behaviour: the second :20: overwrites the global reference and a
+    # single transaction is produced.
+    transactions = mt940.parse(DATA)
+    assert len(transactions) == 1
+    assert transactions[0].data['transaction_reference'] == 'REF2'
+
+
+def test_transaction_boundary_opt_in_via_parse():
+    transactions = mt940.parse(
+        DATA, transaction_boundary={'transaction_reference_number'}
+    )
+    refs = [t.data.get('transaction_reference') for t in transactions]
+    assert refs == ['REF1', 'REF2']
+
+
+def test_transaction_boundary_opt_in_via_transactions():
+    transactions = mt940.models.Transactions(
+        transaction_boundary={'transaction_reference_number'}
+    )
+    transactions.parse(DATA)
+    assert len(transactions) == 2

--- a/mt940_tests/test_issues/test_long_references.py
+++ b/mt940_tests/test_issues/test_long_references.py
@@ -1,0 +1,62 @@
+"""Regression tests for banks that exceed the SWIFT field-length caps.
+
+- Issue #111 (GLS / Atruvia): customer_reference longer than 16 chars.
+- Issue #117 (Wise): extra_details (supplementary details) over 34 chars.
+"""
+
+import mt940
+
+
+def test_issue_111_long_customer_reference():
+    # GLS / Atruvia sends a 35-char customer reference followed by the //
+    # bank-reference delimiter; the old 16-char cap raised a RuntimeError.
+    data = """:20:STARTUMS
+:25:GENODEF1XXX/1234567890
+:28C:0
+:60F:C220706EUR100,00
+:61:2207060706DR20,NTRFBIPI-dvT1FzfMqvzF5HaU4oetlH7SGRkonU//2022070616391534000
+:86:116?00Ueberweisung
+:62F:C220706EUR80,00
+"""
+    transaction = mt940.parse(data)[0]
+    assert (
+        transaction.data['customer_reference']
+        == 'BIPI-dvT1FzfMqvzF5HaU4oetlH7SGRkonU'
+    )
+    assert transaction.data['bank_reference'] == '2022070616391534000'
+    assert str(transaction.data['amount']) == '-20 EUR'
+
+
+def test_issue_117_long_extra_details():
+    # Wise sends supplementary details longer than the 34-char SWIFT cap.
+    long_details = 'Sent money to John Doe for invoice 12345 reference ABCDE'
+    assert len(long_details) > 34
+    data = f""":20:STARTUMS
+:25:WISE/1234567890
+:28C:0
+:60F:C220706EUR100,00
+:61:2207060706C50,00NTRFsomeref//bankref123
+{long_details}
+:86:116?00Payment
+:62F:C220706EUR150,00
+"""
+    transaction = mt940.parse(data)[0]
+    assert transaction.data['extra_details'] == long_details
+    assert str(transaction.data['amount']) == '50.00 EUR'
+
+
+def test_rabobank_same_line_extra_details_unchanged():
+    # Rabobank packs a 16-char (space-padded) customer reference plus extra
+    # text on the same line, with no // delimiter. The relaxation must keep
+    # splitting these (backwards compatibility).
+    data = """:20:STARTUMS
+:25:NL12RABO0123456789
+:28C:0
+:60F:C220706EUR100,00
+:61:2207060706C10,00N654NONREF          TOMTE TUMMETOT AMERSFOORT
+:86:116?00Payment
+:62F:C220706EUR110,00
+"""
+    transaction = mt940.parse(data)[0]
+    assert transaction.data['customer_reference'] == 'NONREF          '
+    assert transaction.data['extra_details'] == 'TOMTE TUMMETOT AMERSFOORT'

--- a/mt940_tests/test_issues/test_long_references.py
+++ b/mt940_tests/test_issues/test_long_references.py
@@ -9,7 +9,9 @@ import mt940
 
 def test_issue_111_long_customer_reference():
     # GLS / Atruvia sends a 35-char customer reference followed by the //
-    # bank-reference delimiter; the old 16-char cap raised a RuntimeError.
+    # bank-reference delimiter. This is handled by the opt-in StatementGLS tag
+    # (relaxing the default would change Rabobank-style same-line parsing).
+    gls = mt940.tags.StatementGLS()
     data = """:20:STARTUMS
 :25:GENODEF1XXX/1234567890
 :28C:0
@@ -18,13 +20,31 @@ def test_issue_111_long_customer_reference():
 :86:116?00Ueberweisung
 :62F:C220706EUR80,00
 """
-    transaction = mt940.parse(data)[0]
+    transaction = mt940.parse(data, tags={gls.id: gls})[0]
     assert (
         transaction.data['customer_reference']
         == 'BIPI-dvT1FzfMqvzF5HaU4oetlH7SGRkonU'
     )
     assert transaction.data['bank_reference'] == '2022070616391534000'
     assert str(transaction.data['amount']) == '-20 EUR'
+
+
+def test_same_line_details_with_double_slash_preserved():
+    # A // inside same-line details (e.g. a URL) must NOT be treated as the
+    # bank-reference delimiter by the default Statement tag (backwards-compat
+    # guard: the GLS support is opt-in for exactly this reason).
+    data = """:20:STARTUMS
+:25:NL12RABO0123456789
+:28C:0
+:60F:C220706EUR100,00
+:61:2207060706C10,00N654NONREF          HTTP://SHOP EXAMPLE
+:86:116?00Payment
+:62F:C220706EUR110,00
+"""
+    transaction = mt940.parse(data)[0]
+    assert transaction.data['customer_reference'] == 'NONREF          '
+    assert transaction.data['extra_details'] == 'HTTP://SHOP EXAMPLE'
+    assert transaction.data.get('bank_reference') is None
 
 
 def test_issue_117_long_extra_details():

--- a/mt940_tests/test_processors_issue109.py
+++ b/mt940_tests/test_processors_issue109.py
@@ -6,10 +6,11 @@ These tests drive the real segment pipeline (`_parse_segments` ->
 matches what banks actually send (segment keys are always two characters).
 """
 
-from mt940 import processors
+import mt940
 
 
 def _purpose(detail_str: str) -> list[str]:
+    processors = mt940.processors
     segments = processors._parse_segments(detail_str)
     return processors._process_segments(segments)[processors.DETAIL_KEYS['20']]
 
@@ -32,8 +33,6 @@ def test_value_not_ending_in_label_is_unchanged():
 
 
 def test_issue_109_end_to_end():
-    import mt940
-
     data = """:20:STARTUMS
 :25:GENODEF1XXX/1234567890
 :28C:0

--- a/mt940_tests/test_processors_issue109.py
+++ b/mt940_tests/test_processors_issue109.py
@@ -1,43 +1,50 @@
-import collections
+"""Issue #109: strip a dangling ' BIC'/' IBAN' label (a label with no value)
+from the end of a transaction-detail segment.
+
+These tests drive the real segment pipeline (`_parse_segments` ->
+`_process_segments`) instead of fabricating segment dictionaries, so the input
+matches what banks actually send (segment keys are always two characters).
+"""
 
 from mt940 import processors
 
 
-def test_process_segments_29_bic_removed():
-    # Create a pseudo OrderedDict similar to what _parse_segments returns.
-    tmp = collections.OrderedDict()
-    # Segment with key "29" ending with " BIC" should have the trailing
-    # " BIC" removed.
-    tmp['29'] = 'DE69280123450012345670 BIC'
-    result = processors._process_segments(tmp)
-    key20 = processors.DETAIL_KEYS['20']
-    # After removal, expect "DE69280123450012345670" to be appended.
-    assert key20 in result
-    assert result[key20] == ['DE69280123450012345670']
+def _purpose(detail_str: str) -> list[str]:
+    segments = processors._parse_segments(detail_str)
+    return processors._process_segments(segments)[processors.DETAIL_KEYS['20']]
 
 
-def test_process_segments_28d_iban_removed():
-    # Create a pseudo OrderedDict similar to what _parse_segments returns.
-    tmp = collections.OrderedDict()
-    # Segment with key "28D" ending with " IBAN" should have the trailing
-    # " IBAN" removed.
-    tmp['28D'] = 'DE69280123450012345670 IBAN'
-    result = processors._process_segments(tmp)
-    key20 = processors.DETAIL_KEYS['20']
-    # After removal, expect "DE69280123450012345670" to be appended.
-    assert key20 in result
-    assert result[key20] == ['DE69280123450012345670']
+def test_dangling_bic_is_stripped():
+    # ?29 ends with a bare ' BIC' label and no BIC value (issue #109).
+    purpose = _purpose('?20Purpose?29 DE69280123450012345670 BIC')
+    assert purpose == ['Purpose', ' DE69280123450012345670']
 
 
-def test_process_segments_other_fields():
-    # Test normal behavior for other segments.
-    tmp = collections.OrderedDict()
-    # Field "20" is present in DETAIL_KEYS so goes to its own key.
-    tmp['20'] = 'Purpose Text'
-    # Field "29" that does not end with " BIC" should remain unchanged.
-    tmp['29'] = 'Another Example'
-    result = processors._process_segments(tmp)
-    key20 = processors.DETAIL_KEYS['20']
-    # Both values should be appended to the same key.
-    assert key20 in result
-    assert result[key20] == ['Purpose Text', 'Another Example']
+def test_dangling_iban_is_stripped():
+    # The same pattern with a bare ' IBAN' label must also be stripped.
+    purpose = _purpose('?20Purpose?29 DE69280123450012345670 IBAN')
+    assert purpose == ['Purpose', ' DE69280123450012345670']
+
+
+def test_value_not_ending_in_label_is_unchanged():
+    purpose = _purpose('?20Legit purpose text?29trailing content')
+    assert purpose == ['Legit purpose text', 'trailing content']
+
+
+def test_issue_109_end_to_end():
+    import mt940
+
+    data = """:20:STARTUMS
+:25:GENODEF1XXX/1234567890
+:28C:0
+:60F:C240123EUR100,00
+:61:2401231020DR30,00NDDTKREF+
+:86:105?00Basislastschrift?20EREF+DD-1?29 DE69280123450012345670 BIC
+:62F:C240123EUR70,00
+"""
+    transaction = mt940.parse(data)[0]
+    # The dangling ' BIC' must not appear anywhere in the parsed details,
+    # while the actual reference value is preserved.
+    blob = ' '.join(str(v) for v in transaction.data.values())
+    assert ' BIC' not in blob
+    assert 'DE69280123450012345670' in blob


### PR DESCRIPTION
Goes through the open issues/PRs (and stale-closed ones) and implements everything safely fixable, **without breaking backwards compatibility**. Every parser change was verified against the full fixture set (parse → `JSONEncoder` → diff): **zero change to existing output**. New behaviour that would otherwise change output is opt-in.

## Bug fixes
- **#121** — `entry_date` now resolves across year boundaries (e.g. value date Jan 2026 + entry date Dec → 2025-12-30) instead of staying in the value-date year. `guessed_entry_date` kept as an alias.
- **#111** (GLS / Atruvia) — `customer_reference` may exceed 16 chars **when a `//` bank reference follows**; the 16x cap is kept when there's no `//`, so banks that pack same-line extra data (e.g. Rabobank) are unaffected.
- **#117** (Wise) — `extra_details` may exceed 34 chars.
- **#109** — strip a dangling ` BIC`/` IBAN` label (a label with no value) from detail segments; the old `'28D'` branch was dead code (segment keys are always 2 chars). IBAN handling now actually works.

## Robustness
- **#106** — regression test: parsing works when `sys.stdout`/`sys.stderr` are `None` (sandboxed/serverless). The dependency was already removed by the modernization; this locks it in.

## New (opt-in, BC-safe) feature
- **#110** — `transaction_boundary` option on `mt940.parse()` / `Transactions(...)`: an iterable of tag *slugs* that each start a new transaction (e.g. `{'transaction_reference_number'}` to start one per `:20:`). **Defaults to today's behaviour** (only `:61:` starts a transaction). Documented in the README. This is the configurable "dialect"-style hook requested in the issue, rather than a default change (which previously broke ABN AMRO, #26).

## Verification
- Full `tox` green: py310–313, lint, pyright, mypy, pyrefly, docs, coverage **100%**, codespell, repo-review.
- Fixture parse-diff harness: **no change to any existing fixture output**.

Fixes #121
Fixes #111
Fixes #117
Fixes #109
Fixes #110
Fixes #106