### PR TITLE
Settle the :61: RC reversal sign left pending in #127

### DIFF
--- a/mt940/models.py
+++ b/mt940/models.py
@@ -195,13 +195,25 @@ class Amount(Model):
 
     Args:
         amount (str): Amount using either a , or a . as decimal separator
-        status (str): Either C or D for credit or debit respectively
+        status (str): The debit/credit mark of field 61, one of C, D, RC or
+            RD. C and RD are positive, D and RC are negative.
         currency (str): A 3 letter currency (e.g. EUR)
 
     >>> Amount('123.45', 'C', 'EUR')
     <123.45 EUR>
     >>> Amount('123.45', 'D', 'EUR')
     <-123.45 EUR>
+
+    A reversal of a credit takes the money back out of the account, so it
+    is negative like a debit:
+
+    >>> Amount('123.45', 'RC', 'EUR')
+    <-123.45 EUR>
+
+    And a reversal of a debit puts it back in, so it is positive:
+
+    >>> Amount('123.45', 'RD', 'EUR')
+    <123.45 EUR>
     """
 
     def __init__(
@@ -213,16 +225,22 @@ class Amount(Model):
     ) -> None:
         """Coerce ``amount`` to a signed :class:`decimal.Decimal`.
 
-        ``status`` is ``'C'`` for credit (positive) or ``'D'`` for debit, in
-        which case the amount is negated. Extra keyword arguments are ignored
-        so a parsed tag dictionary can be splatted in directly.
+        ``status`` is the field 61 debit/credit mark. The amount is negated
+        for the two marks that take money out of the account. Extra keyword
+        arguments are ignored so a parsed tag dictionary can be splatted in
+        directly.
         """
         self.amount = decimal.Decimal(amount.replace(',', '.'))
         self.currency = currency
 
-        # C = credit, D = debit
+        # C = credit, D = debit, RC = reversal of a credit (so money leaves
+        # the account, like a debit), RD = reversal of a debit (so money
+        # comes back in, like a credit).
+        #
+        # Compared case-insensitively because the tag patterns compile with
+        # re.IGNORECASE, so a lowercase mark reaches this constructor as-is.
 
-        if status == 'D':
+        if status.upper() in ('D', 'RC'):
             self.amount = -self.amount
 
     def __eq__(self, other: object) -> bool:

--- a/mt940_tests/betterplace/sepa_mt9401.yml
+++ b/mt940_tests/betterplace/sepa_mt9401.yml
@@ -368,7 +368,7 @@ transactions:
     additional_purpose: null
     amount: !!python/object:mt940.models.Amount
       amount: !!python/object/apply:decimal.Decimal
-      - '204.88'
+      - '-204.88'
       currency: EUR
     applicant_bin: null
     applicant_name: null
@@ -973,7 +973,7 @@ transactions:
     additional_purpose: null
     amount: !!python/object:mt940.models.Amount
       amount: !!python/object/apply:decimal.Decimal
-      - '204.88'
+      - '-204.88'
       currency: EUR
     applicant_bin: null
     applicant_name: null

--- a/mt940_tests/test_issues/test_issue130_reversal_sign.py
+++ b/mt940_tests/test_issues/test_issue130_reversal_sign.py
@@ -1,0 +1,99 @@
+"""Issue #130: the ``:61:`` reversal marks must carry the right sign.
+
+Field 61 defines four debit/credit marks, not two: ``C``, ``D``, ``RC`` (a
+reversal of a credit) and ``RD`` (a reversal of a debit). A reversal of a
+credit takes the money back out of the account, so it belongs on the debit
+side; a reversal of a debit puts it back in.
+
+``RC`` used to come back positive, which is a silent error: nothing raised,
+nothing warned, and the figure that came out was plausible.
+"""
+
+import decimal
+import os
+
+import mt940
+import pytest
+
+BETTERPLACE = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+    'betterplace',
+    'sepa_mt9401.sta',
+)
+
+
+def statement(mark):
+    return f""":20:REF
+:25:ACC
+:60F:C200101EUR0,00
+:61:2001010101{mark}5,00NTRFa//b
+:86:116?00detail
+"""
+
+
+@pytest.mark.parametrize(
+    ('mark', 'expected'),
+    [
+        ('C', decimal.Decimal('5.00')),
+        ('D', decimal.Decimal('-5.00')),
+        # A reversed credit is money leaving the account.
+        ('RC', decimal.Decimal('-5.00')),
+        # A reversed debit is money coming back in.
+        ('RD', decimal.Decimal('5.00')),
+        # The tag patterns compile with re.IGNORECASE, so a lowercase mark
+        # parses and has to be signed the same way.
+        ('rc', decimal.Decimal('-5.00')),
+        ('d', decimal.Decimal('-5.00')),
+    ],
+)
+def test_reversal_marks_get_the_sign_of_their_direction(mark, expected):
+    transactions = mt940.parse(statement(mark))
+    assert len(transactions) == 1
+    transaction = transactions[0]
+    assert transaction.data['status'] == mark
+    assert transaction.data['amount'].amount == expected
+
+
+def test_reversed_credits_in_the_betterplace_statement_are_negative():
+    # This file ships with the library and carries two RC entries of 204,88.
+    reversals = [
+        transaction
+        for transaction in mt940.parse(BETTERPLACE)
+        if transaction.data['status'] == 'RC'
+    ]
+    assert len(reversals) == 2
+    for transaction in reversals:
+        assert transaction.data['amount'].amount == decimal.Decimal('-204.88')
+
+
+def test_every_betterplace_statement_matches_its_own_closing_balance():
+    # The bank states its own opening and closing balance in :60F: and :62F:,
+    # so the entries in between have to add up to the difference. This is the
+    # arithmetic that the RC sign used to break: the two statements holding a
+    # reversal each computed a closing balance 409,76 HIGHER than the one the
+    # bank states, which is twice the 204,88 that was counted as arriving
+    # instead of leaving.
+    #
+    # parse_statements rather than parse, because parse merges every block of
+    # the file into one Transactions and keeps only the last pair of balances.
+    checked = 0
+
+    for transactions in mt940.parse_statements(BETTERPLACE):
+        opening = transactions.data.get('final_opening_balance')
+        closing = transactions.data.get('final_closing_balance')
+        if opening is None or closing is None:
+            continue
+
+        total = sum(
+            (
+                transaction.data['amount'].amount
+                for transaction in transactions
+            ),
+            decimal.Decimal(0),
+        )
+        assert opening.amount.amount + total == closing.amount.amount
+        checked += 1
+
+    # Pinned so the test cannot quietly become vacuous if the file or the
+    # splitting changes.
+    assert checked == 15


### PR DESCRIPTION
Fixes #130, and settles the pending decision behind the `xfail` you added in 18a6d95.

I filed #130 before spotting #127. Apologies for the duplicate, your `test_statement_rc_reversal_amount_is_negative`
already has the analysis, and its reason line says exactly what I would have said. So rather than
re-report it, here is the thing that decides it: the fixture already in the repo answers the sign
question on its own.

### The arithmetic

`mt940_tests/betterplace/sepa_mt9401.sta` holds 26 statement blocks, 15 of which declare both a
`:60F:` opening and a `:62F:` closing balance. Two of those 15 carry an `RC` entry of 204,88, and
those two are exactly the two whose entries do not add up to the balance the bank itself states:

| | before | after |
|---|---|---|
| statements matching their own `:62F:` | 13 / 15 | 15 / 15 |
| the two statements holding an `RC` | each 409,76 **too high** | each exact |

409,76 is twice 204,88, the signature of an amount counted as arriving instead of leaving. Since
the bank publishes the closing balance in the file, the fixture is its own witness.

The file corroborates it a second way: in block 4 that `RC` of 204,88 has a `C` of the same
amount immediately before it, and the `RC`'s `:86:` subfield `?00` reads `SEPA-UEBERW/STORNO`.
Block 0's reads `SAMMLER/STORNO`. The `:62F:` only closes if that `RC` nets out.

I mention this because the German wording alone would not settle it: the MultiCash description
gives only "RC = Storno Credit", which is arguable either way. Danske Bank's structured MT940
description is explicit where that is terse, reproducing subfield 3 as "RC for Reversal of credit
(debit entry), RD for Reversal of debit (credit entry)", and Huntington's developer docs say the
same. ING and Rabobank name the marks without giving a direction at all. So the specs are split
on how explicit they are, and the fixture is what actually settles it.

### The change

```python
# C = credit, D = debit, RC = reversal of a credit (so money leaves
# the account, like a debit), RD = reversal of a debit (so money
# comes back in, like a credit).
#
# Compared case-insensitively because the tag patterns compile with
# re.IGNORECASE, so a lowercase mark reaches this constructor as-is.

if status.upper() in ('D', 'RC'):
    self.amount = -self.amount
```

`RD` needs nothing: `'RD' != 'D'`, so it was never negated, and positive is the correct sign for
a reversed debit. Of the four MT940 marks, only `RC` was wrong.

The `.upper()` is deliberate and matches your ff3d24a. `RE_FLAGS` includes `re.IGNORECASE`, so
`:61:2001010101rc5,00...` parses with `status == 'rc'`, and a plain lowercase `d` was never
negated either. Two parametrised cases cover both.

### Two things you should know before merging

1. **This will break #127 if that lands too.** `test_statement_rc_reversal_amount_is_negative` is
   `strict=True`, so it turns into `XPASS(strict)`. I checked: applying this on
   `feature/full-audit-fixes` gives 2 failures, that test and the betterplace golden. **If you
   would rather I close this and push the same change into #127 instead, say the word**, that is
   probably cleaner for you and I do not mind at all.
2. `sepa_mt9401.yml` changes on two amounts and nothing else. I did not use `WRITE_YAML_FILES=1`,
   because regenerating rewrites 51 of the 52 goldens (anchor renumbering, an added
   `transaction_boundary` key, refreshed embedded tag patterns) and buries the two lines that
   matter. That churn also appears on a clean `develop`, so the goldens look stale independently
   of this change. Happy to regenerate the normal way if you would rather have that.

### Scope

Not touched: `StatementASNB`'s `[A-Z]?[DC]` also accepts `EC`/`ED`, which parse and stay positive
both before and after this. That is pre-existing and a separate question, and MT942 is where
those marks actually belong.

### Checks

163 to 171 passing, coverage still 100%. `ruff check`, `mypy` and `codespell` clean.
`ruff format --check` flags `README.md`, which it also does on a clean `develop`, so I left it
alone.

Found while building a normalisation layer on top of this library, which is a good library and
the reason I did not write my own MT940 parser.