### PR TITLE
Every output change since 5.0.0 is opt-in through mt940.Options

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,41 @@ with open('mt940_tests/ASNB/mt940.txt') as fh:
 pprint.pprint(transactions.data, sort_dicts=False)
 ```
 
+### Parser fixes (opt-in)
+
+Several parsing fixes change the output for input that 5.0.0 accepted without
+complaint. Because that would break existing users, every one of them is off
+by default and switched on through `mt940.Options`. The next major release
+turns them all on.
+
+```python
+import mt940
+
+options = mt940.Options(reversal_sign=True, applicant_iban=True)
+transactions = mt940.parse(
+    'mt940_tests/betterplace/sepa_mt9401.sta', options=options
+)
+
+# Or take every fix at once, which is what the next major release does.
+transactions = mt940.parse('statement.sta', options=mt940.Options.all())
+```
+
+| Option | Default (5.0.0) | Switched on |
+|---|---|---|
+| `applicant_iban` | `?31` is prepended to `applicant_name` | `?31` is `applicant_iban` (issue #132, the 4.x behaviour) |
+| `merge_keeps_values` | a structured `:86:` overwrites other tags' values with `None` for sub-fields it lacks | existing values survive, so the `:61:` customer reference keeps its value |
+| `reversal_sign` | the `RC` reversal mark gives a positive amount | `RC` is negative like the debit it is (issue #130) |
+| `case_insensitive_marks` | a lowercase `d` or `rc` mark does not sign the amount | lowercase marks work like uppercase ones |
+| `timezone_offset` | a `:13D:` offset of `+0100` is read as 100 minutes | `+0100` is one hour |
+| `unbounded_details` | `:86:` details are cut after nine chunks of 65 characters | details of any length are kept |
+| `non_swift_free_text` | an `:NS:` line without a two-digit sub-tag loses its content | the content is kept |
+| `floor_limit_blank_mark` | a blank `:34F:` mark yields a key with a leading space and no currency | it yields both floor limits and the currency |
+| `strip_bom` | a leading byte-order mark hides the first `:20:` tag | the mark is dropped |
+| `gvc_leading_text` | free text before the first GVC keyword is lost when it contains a `+` | the text is kept |
+
+Crash fixes need no option: input that made 5.0.0 raise now parses in every
+mode.
+
 ## Supported tags
 
 | Tag | Meaning |

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -45,6 +45,10 @@ exclude_patterns = ['_build', 'html', 'doctrees']
 
 # -- Autodoc / Napoleon -------------------------------------------------------
 autodoc_typehints = 'description'
+# mt940.Options is a re-export of mt940.options.Options, so the short type
+# name in a signature has two documented targets. Only that ambiguity is
+# silenced: unresolved references keep their ref.class/ref.func warnings.
+suppress_warnings = ['ref.python']
 autodoc_member_order = 'bysource'
 autodoc_default_options = {
     'members': True,

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -104,6 +104,22 @@ Some banks (e.g. GLS / Atruvia) put a customer reference longer than the SWIFT
     gls = mt940.tags.StatementGLS()
     transactions = mt940.parse('statement.sta', tags={gls.id: gls})
 
+Parser fixes
+------------
+
+Several parsing fixes change the output for input that 5.0.0 accepted, so
+each of them is off by default and switched on through
+:class:`mt940.options.Options`. The class documents every switch, and
+:meth:`mt940.options.Options.all` enables all of them, which is what the next
+major release will do by default::
+
+    import mt940
+
+    options = mt940.Options(reversal_sign=True, applicant_iban=True)
+    transactions = mt940.parse('statement.sta', options=options)
+
+    transactions = mt940.parse('statement.sta', options=mt940.Options.all())
+
 Statements from the Dutch bank ASN
 ----------------------------------
 

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -42,4 +42,6 @@ pre-push:
     ty:
       run: uv run ty check
     test:
-      run: uv run pytest -q -x --no-cov -p no:randomly
+      # Fixed order for a fast, deterministic gate. The plugin stays loaded
+      # because pyproject lists it as required.
+      run: uv run pytest -q -x --no-cov --randomly-dont-reorganize

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,6 +1,8 @@
 # Git hooks for mt940 development.
-# Install with: lefthook install
-# (the `lefthook` binary ships with the `lefthook` dev dependency)
+# Install with: uv run lefthook install
+#
+# Every command goes through `uv run` so the hooks use the project's own
+# tool versions, whatever is (or is not) on the shell's PATH.
 #
 # pre-commit stays sub-second: only the staged files, only auto-fixers and the
 # spell-checker. pre-push runs the full lint, every type checker and a fast
@@ -11,33 +13,33 @@ pre-commit:
   commands:
     ruff-check:
       glob: '*.py'
-      run: ruff check --fix {staged_files}
+      run: uv run ruff check --fix {staged_files}
       stage_fixed: true
     ruff-format:
       glob: '*.py'
-      run: ruff format {staged_files}
+      run: uv run ruff format {staged_files}
       stage_fixed: true
     taplo:
       glob: '*.toml'
-      run: taplo fmt --check {staged_files}
+      run: uv run taplo fmt --check {staged_files}
     codespell:
       # No file args: honour the skip patterns in [tool.codespell].
-      run: codespell
+      run: uv run codespell
 
 pre-push:
   parallel: true
   commands:
     ruff:
-      run: ruff check
+      run: uv run ruff check
     ruff-format:
-      run: ruff format --check
+      run: uv run ruff format --check
     mypy:
-      run: mypy && mypy --python-version 3.12 docs/conf.py
+      run: uv run mypy && uv run mypy --python-version 3.12 docs/conf.py
     basedpyright:
-      run: basedpyright
+      run: uv run basedpyright
     pyrefly:
-      run: pyrefly check
+      run: uv run pyrefly check
     ty:
-      run: ty check
+      run: uv run ty check
     test:
-      run: pytest -q -x --no-cov -p no:randomly
+      run: uv run pytest -q -x --no-cov -p no:randomly

--- a/mt940/__init__.py
+++ b/mt940/__init__.py
@@ -27,10 +27,12 @@ Example:
 from . import json, models, parser, processors, tags, utils
 from .__about__ import __version__
 from .json import JSONEncoder
+from .options import Options
 from .parser import parse, parse_statements
 
 __all__ = [
     'JSONEncoder',
+    'Options',
     '__version__',
     'json',
     'models',

--- a/mt940/_types.py
+++ b/mt940/_types.py
@@ -1,23 +1,25 @@
 """Shared type aliases and processor protocols.
 
-These are the precise types used across the public API. At runtime the module
-is a *leaf*: it imports nothing from the rest of the package, so it never
-participates in an import cycle. The model and tag classes named by the
-processor protocols are imported for type checking only.
+These are the precise types used across the public API. The module is a
+*leaf*: it imports nothing from the rest of the package, so it never
+participates in an import cycle. That is also why the processor protocols
+type their ``transactions`` and ``tag`` arguments as :data:`~typing.Any`:
+naming the model and tag classes would need an import, and
+:func:`typing.get_type_hints` has to resolve these signatures at runtime, as
+it did in 5.0.0. The concrete processors in :mod:`mt940.processors` annotate
+them precisely.
 """
 
 from __future__ import annotations
 
 import os
 from collections.abc import Callable
-from typing import IO, TYPE_CHECKING, Any, Protocol
-
-if TYPE_CHECKING:
-    from . import models, tags
+from typing import IO, Any, Protocol
 
 #: Accepted input for :func:`mt940.parse` and :func:`mt940.parse_statements`:
-#: a path, raw ``str``/``bytes`` data, or an open binary/text file handle.
-Source = str | bytes | os.PathLike[str] | IO[str] | IO[bytes]
+#: a path, raw ``str``/``bytes`` data, an open file descriptor, or an open
+#: binary/text file handle.
+Source = str | bytes | os.PathLike[str] | int | IO[str] | IO[bytes]
 
 #: A parsed tag dictionary. Intentionally dynamic: the available keys are
 #: tag- and bank-specific, so a precise ``TypedDict`` would misrepresent it.
@@ -29,8 +31,9 @@ class PreProcessor(Protocol):
 
     def __call__(
         self,
-        transactions: models.Transactions,
-        tag: tags.Tag,
+        # Any rather than the model and tag classes: see the module docstring.
+        transactions: Any,  # noqa: ANN401
+        tag: Any,  # noqa: ANN401
         tag_dict: TagDict,
         /,
         *args: Any,
@@ -42,8 +45,9 @@ class PostProcessor(Protocol):
 
     def __call__(
         self,
-        transactions: models.Transactions,
-        tag: tags.Tag,
+        # Any rather than the model and tag classes: see the module docstring.
+        transactions: Any,  # noqa: ANN401
+        tag: Any,  # noqa: ANN401
         tag_dict: TagDict,
         result: TagDict,
         /,

--- a/mt940/models.py
+++ b/mt940/models.py
@@ -24,6 +24,7 @@ from typing import TYPE_CHECKING, Any, ClassVar, overload
 import mt940
 
 from . import processors, utils
+from .options import Options
 
 if TYPE_CHECKING:
     from typing_extensions import Self
@@ -516,12 +517,16 @@ class Transactions(Sequence[Transaction]):
         """
         self.__dict__.update(state)
         self.processors: Processors = self.DEFAULT_PROCESSORS.copy()
+        # Pickles written by 5.0.0 predate the options attribute.
+        _ = self.__dict__.setdefault('options', Options())
 
     def __init__(
         self,
         processors: Processors | None = None,
         tags: dict[int | str, mt940.tags.Tag] | None = None,
         transaction_boundary: Iterable[str] | None = None,
+        *,
+        options: Options | None = None,
     ) -> None:
         """Create an empty collection, optionally customizing parsing.
 
@@ -533,7 +538,10 @@ class Transactions(Sequence[Transaction]):
                 (issue #110). By default only ``:61:`` starts one; a bare
                 string is treated as a single slug. Omit to keep the legacy
                 behaviour.
+            options: Opt-in behaviours, see :class:`mt940.options.Options`.
+                Omit to parse exactly like release 5.0.0.
         """
+        self.options: Options = options or Options()
         self.processors = self.DEFAULT_PROCESSORS.copy()
         self.tags: MutableMapping[int | str, mt940.tags.Tag] = dict(
             self.default_tags()

--- a/mt940/models.py
+++ b/mt940/models.py
@@ -24,12 +24,16 @@ from typing import TYPE_CHECKING, Any, ClassVar, overload
 import mt940
 
 from . import processors, utils
+
+# Kept at runtime: 5.0.0 exposed it as mt940.models.Processors.
+from ._types import Processors as Processors  # noqa: PLC0414, TC001
 from .options import Options
 
 if TYPE_CHECKING:
     from typing_extensions import Self
 
-    from ._types import Processors
+#: Sentinel for attributes that are absent, as opposed to ``None``.
+_MISSING = object()
 
 
 #: MT940 carries two-digit years. Anything below this limit is taken to be
@@ -73,20 +77,21 @@ class FixedOffset(datetime.tzinfo):
             offset = int(offset)
         self._offset: datetime.timedelta = datetime.timedelta(minutes=offset)
 
-    def utcoffset(
-        self, _dt: datetime.datetime | None, /
-    ) -> datetime.timedelta:
+    def utcoffset(self, dt: datetime.datetime | None) -> datetime.timedelta:
         """Return the fixed offset east of UTC."""
+        del dt
         return self._offset
 
     def dst(  # noqa: PLR6301 (the tzinfo API is instance-based)
-        self, _dt: datetime.datetime | None, /
+        self, dt: datetime.datetime | None
     ) -> datetime.timedelta:
         """Return a zero DST adjustment (fixed offsets have no DST)."""
+        del dt
         return datetime.timedelta(0)
 
-    def tzname(self, _dt: datetime.datetime | None, /) -> str:
+    def tzname(self, dt: datetime.datetime | None) -> str:
         """Return the offset's name."""
+        del dt
         return self._name
 
 
@@ -225,31 +230,51 @@ class Amount(Model):
     >>> Amount('123.45', 'D', 'EUR')
     <-123.45 EUR>
 
-    A reversal of a credit takes the money back out of the account, so it
-    is negative like a debit:
+    Release 5.0.0 negated a plain ``D`` only, so a reversal of a credit
+    (``RC``) and a lowercase ``d`` came back positive. That stays the
+    default. Opt in through :class:`mt940.options.Options` to sign them:
 
     >>> Amount('123.45', 'RC', 'EUR')
+    <123.45 EUR>
+    >>> Amount(
+    ...     '123.45', 'RC', 'EUR', options=mt940.Options(reversal_sign=True)
+    ... )
     <-123.45 EUR>
+    >>> Amount(
+    ...     '1.00',
+    ...     'd',
+    ...     'EUR',
+    ...     options=mt940.Options(case_insensitive_marks=True),
+    ... )
+    <-1.00 EUR>
 
-    And a reversal of a debit puts it back in, so it is positive:
+    A reversal of a debit puts money back in, so it stays positive:
 
-    >>> Amount('123.45', 'RD', 'EUR')
+    >>> Amount('123.45', 'RD', 'EUR', options=mt940.Options.all())
     <123.45 EUR>
     """
 
     def __init__(
         self,
         amount: str,
-        status: str,
+        status: str | None,
         currency: str | None = None,
+        *,
+        options: Options | None = None,
         **kwargs: Any,
     ) -> None:
         """Coerce ``amount`` to a signed :class:`decimal.Decimal`.
 
-        ``status`` is the field 61 debit/credit mark. The amount is negated
-        for the two marks that take money out of the account. Extra keyword
-        arguments are ignored so a parsed tag dictionary can be splatted in
-        directly.
+        Args:
+            amount: The amount, with ``,`` or ``.`` as decimal separator.
+            status: The debit/credit mark of field 61. ``None`` counts as
+                no mark.
+            currency: The three-letter currency code.
+            options: Which marks negate the amount, see
+                :class:`mt940.options.Options`. By default only a plain
+                ``D`` does, like release 5.0.0.
+            **kwargs: Ignored, so a parsed tag dictionary can be splatted
+                in directly.
         """
         del kwargs
         self.amount: decimal.Decimal = decimal.Decimal(
@@ -257,14 +282,16 @@ class Amount(Model):
         )
         self.currency: str | None = currency
 
-        # C = credit, D = debit, RC = reversal of a credit (so money leaves
-        # the account, like a debit), RD = reversal of a debit (so money
-        # comes back in, like a credit).
-        #
-        # Compared case-insensitively because the tag patterns compile with
-        # re.IGNORECASE, so a lowercase mark reaches this constructor as-is.
-
-        if status.upper() in {'D', 'RC'}:
+        # C = credit, D = debit, RC = reversal of a credit (money leaves the
+        # account, like a debit), RD = reversal of a debit (money comes back
+        # in, like a credit). The tag patterns compile with re.IGNORECASE,
+        # so a lowercase mark reaches this constructor as-is.
+        options = options or Options()
+        mark = status or ''
+        if options.case_insensitive_marks:
+            mark = mark.upper()
+        debit_marks = {'D', 'RC'} if options.reversal_sign else {'D'}
+        if mark in debit_marks:
             self.amount = -self.amount
 
     def __eq__(self, other: object) -> bool:
@@ -306,20 +333,17 @@ class SumAmount(Amount):
         self.number: int = number
 
     def __eq__(self, other: object) -> bool:
-        """Return whether ``other`` sums the same amount over as many entries.
+        """Return whether ``other`` is an equal-valued amount.
 
-        Two totals over a different number of entries are different totals,
-        so ``number`` takes part in the comparison.
+        ``number`` is informational and takes no part, as in 5.0.0: a plain
+        :class:`Amount` of the same value compares equal, and so do two
+        totals over a different number of entries.
         """
-        return (
-            isinstance(other, SumAmount)
-            and super().__eq__(other)
-            and self.number == other.number
-        )
+        return super().__eq__(other)
 
     def __hash__(self) -> int:
-        """Return a hash of amount, currency and count, matching ``__eq__``."""
-        return hash((self.amount, self.currency, self.number))
+        """Return the :class:`Amount` hash, matching ``__eq__``."""
+        return super().__hash__()
 
     def __repr__(self) -> str:
         """Return the amount, currency and entry count in angle brackets."""
@@ -354,33 +378,34 @@ class Balance(Model):
         status: str | None = None,
         amount: Amount | str | None = None,
         date: Date | None = None,
+        *,
+        options: Options | None = None,
         **kwargs: Any,
     ) -> None:
         """Store the balance, coercing a string ``amount`` to an ``Amount``.
 
-        The ``:60F:``-style tag patterns allow an empty amount, so an empty
-        string is stored as ``None`` rather than failing the whole parse.
+        An empty amount string is stored as it is, like release 5.0.0 did.
 
         Args:
             status: The debit/credit mark, needed to sign a string amount.
             amount: An :class:`Amount`, or an amount string to coerce.
             date: The balance date.
+            options: Passed on to :class:`Amount` when coercing.
             **kwargs: Extra parsed tag fields, only ``currency`` is used.
 
         Raises:
             ValueError: When ``amount`` is a non-empty string and ``status``
                 is missing.
         """
-        if isinstance(amount, str):
-            if not amount:
-                amount = None
-            elif status is None:
+        if isinstance(amount, str) and amount:
+            if status is None:
                 msg = 'Cannot create Amount without status'
                 raise ValueError(msg)
-            else:
-                amount = Amount(amount, status, kwargs.get('currency'))
+            amount = Amount(
+                amount, status, kwargs.get('currency'), options=options
+            )
         self.status: str | None = status
-        self.amount: Amount | None = amount
+        self.amount: Amount | str | None = amount
         self.date: Date | None = date
 
     def __eq__(self, other: object) -> bool:
@@ -588,12 +613,16 @@ class Transactions(Sequence[Transaction]):
             self.data.get('d_floor_limit'),
         )
 
-        # Floor limits are bare amounts, balances wrap one.
-        if isinstance(balance, Amount):
-            return balance.currency
-        if isinstance(balance, Balance) and balance.amount is not None:
-            return balance.amount.currency
-        return None
+        if balance is None:
+            return None
+        # Floor limits are bare amounts, balances wrap one. Duck-typed, as
+        # in 5.0.0: anything with a currency, or with an amount that has one,
+        # counts. Nothing usable gives None instead of an error.
+        currency: object = getattr(balance, 'currency', _MISSING)
+        if currency is _MISSING:
+            amount: object = getattr(balance, 'amount', None)
+            currency = getattr(amount, 'currency', None)
+        return currency if isinstance(currency, str) else None
 
     @classmethod
     def defaultTags(cls) -> Mapping[int | str, mt940.tags.Tag]:  # noqa: N802
@@ -727,17 +756,22 @@ class Transactions(Sequence[Transaction]):
         New keys are set directly. When both the existing and the incoming
         values are strings, the incoming one is appended on a new line, as
         with a multi-line ``:86:``. A structured ``:86:`` emits ``None`` for
-        every sub-field it does not carry, and such a ``None`` never replaces
-        a value another tag already provided: the ``:61:`` customer reference
-        survives a later structured ``:86:`` without a ``KREF``. Any other
-        incoming value replaces the existing one.
+        every sub-field it does not carry. By default such a ``None``
+        replaces whatever another tag provided, as in 5.0.0, so the ``:61:``
+        customer reference is lost to a later ``:86:`` without a ``KREF``.
+        With :attr:`~mt940.options.Options.merge_keeps_values` a ``None``
+        never replaces an existing value. Either way a later string replaces
+        an existing ``None`` instead of crashing on ``None += str``.
         """
         transaction = self.transactions[-1]
+        keep_values = self.options.merge_keeps_values
         for k, v in result.items():
             existing = transaction.data.get(k)
             if hasattr(existing, 'strip') and hasattr(v, 'strip'):
                 transaction.data[k] += f'\n{v.strip()}'
-            elif v is not None or k not in transaction.data:
+            elif v is None and keep_values and k in transaction.data:
+                continue
+            else:
                 transaction.data[k] = v
 
     @overload
@@ -845,19 +879,6 @@ class TransactionsAndTransaction(  # type: ignore[misc]  # pyright: ignore[repor
     ``:NS:`` is the example: its content is filed both as statement data and
     as details of the current transaction. The class exists so that the
     ``issubclass`` checks against :attr:`~mt940.tags.Tag.scope` succeed for
-    both bases. It is never instantiated.
+    both bases. The parser never creates an instance, but building one works
+    and behaves like an empty :class:`Transactions`, as in 5.0.0.
     """
-
-    # No super call: the constructor refuses instantiation, so there is
-    # nothing to initialise.
-    def __init__(  # pyright: ignore[reportMissingSuperCall]
-        self, *args: object, **kwargs: object
-    ) -> None:
-        """Refuse instantiation, the class is only a scope marker.
-
-        Raises:
-            TypeError: Always.
-        """
-        del args, kwargs
-        msg = f'{type(self).__name__} is a scope marker, it cannot be created'
-        raise TypeError(msg)

--- a/mt940/options.py
+++ b/mt940/options.py
@@ -25,45 +25,55 @@ import dataclasses
 class Options:
     """Switches for behaviour that differs from release 5.0.0.
 
-    Attributes:
-        applicant_iban: File the ``?31`` sub-field of a structured ``:86:``
-            under ``applicant_iban`` instead of prepending it to
-            ``applicant_name`` (issue #132, the 4.x behaviour).
-        merge_keeps_values: A structured ``:86:`` emits ``None`` for every
-            sub-field it does not carry. With this on, such a ``None`` never
-            replaces a value another tag already provided, so the ``:61:``
-            customer reference survives an ``:86:`` without a ``KREF``.
-        reversal_sign: Give the ``:61:`` reversal-of-credit mark ``RC`` a
-            negative amount, like the debit it is (issue #130).
-        case_insensitive_marks: Treat lowercase debit/credit marks (``d``,
-            ``c``, ``rc``, ``rd``) like their uppercase forms when signing an
-            amount. The tag patterns already accept them.
-        timezone_offset: Read the ``:13D:`` offset as hours and minutes, so
-            ``+0100`` is one hour. 5.0.0 read the digits as a minute count.
-        unbounded_details: Keep ``:86:`` details of any length. 5.0.0
-            silently truncated them after nine chunks of 65 characters.
-        non_swift_free_text: Keep the content of ``:NS:`` lines that do not
-            start with a two-digit sub-tag. 5.0.0 replaced such a line with an
-            empty one when it followed a sub-tag line.
-        floor_limit_blank_mark: Treat a blank ``:34F:`` debit/credit mark as
-            "both", giving ``d_floor_limit`` and ``c_floor_limit`` and a
-            statement currency. 5.0.0 produced a key with a leading space.
-        strip_bom: Drop a leading byte-order mark, so the first ``:20:`` tag
-            is recognised. 5.0.0 kept it and lost that tag.
-        gvc_leading_text: Keep free text in front of the first GVC keyword of
-            a ``?20`` purpose when it contains a ``+`` in its first four
-            characters. 5.0.0 dropped that text.
+    Every switch is off by default, so parsing without options gives the
+    5.0.0 output. The next major release switches all of them on.
     """
 
+    #: File the ``?31`` sub-field of a structured ``:86:`` under
+    #: ``applicant_iban`` instead of prepending it to ``applicant_name``
+    #: (issue #132, the 4.x behaviour).
     applicant_iban: bool = False
+
+    #: A structured ``:86:`` emits ``None`` for every sub-field it does not
+    #: carry. With this on, such a ``None`` never replaces a value another
+    #: tag already provided, so the ``:61:`` customer reference survives an
+    #: ``:86:`` without a ``KREF``.
     merge_keeps_values: bool = False
+
+    #: Give the ``:61:`` reversal-of-credit mark ``RC`` a negative amount,
+    #: like the debit it is (issue #130).
     reversal_sign: bool = False
+
+    #: Treat lowercase debit/credit marks (``d``, ``c``, ``rc``, ``rd``) like
+    #: their uppercase forms when signing an amount. The tag patterns already
+    #: accept them.
     case_insensitive_marks: bool = False
+
+    #: Read the ``:13D:`` offset as hours and minutes, so ``+0100`` is one
+    #: hour. 5.0.0 read the digits as a minute count.
     timezone_offset: bool = False
+
+    #: Keep ``:86:`` details of any length. 5.0.0 silently truncated them
+    #: after nine chunks of 65 characters.
     unbounded_details: bool = False
+
+    #: Keep the content of ``:NS:`` lines that do not start with a two-digit
+    #: sub-tag. 5.0.0 replaced such a line with an empty one when it followed
+    #: a sub-tag line.
     non_swift_free_text: bool = False
+
+    #: Treat a blank ``:34F:`` debit/credit mark as "both", giving
+    #: ``d_floor_limit`` and ``c_floor_limit`` and a statement currency.
+    #: 5.0.0 produced a key with a leading space.
     floor_limit_blank_mark: bool = False
+
+    #: Drop a leading byte-order mark, so the first ``:20:`` tag is
+    #: recognised. 5.0.0 kept it and lost that tag.
     strip_bom: bool = False
+
+    #: Keep free text in front of the first GVC keyword of a ``?20`` purpose
+    #: when it contains a ``+`` in its first four characters. 5.0.0 dropped
+    #: that text.
     gvc_leading_text: bool = False
 
     @classmethod

--- a/mt940/options.py
+++ b/mt940/options.py
@@ -1,0 +1,85 @@
+"""Opt-in parser behaviours.
+
+Every attribute of :class:`Options` defaults to what release 5.0.0 does, so
+upgrading never changes parsed output on its own. Each attribute switches on
+one fix that changes the output for input 5.0.0 parsed without complaint.
+Pass an instance to :func:`mt940.parse`, :func:`mt940.parse_statements` or
+:class:`mt940.models.Transactions`, or use :meth:`Options.all` to opt in to
+every fix at once. The next major release enables all of them by default.
+
+Example:
+    >>> import mt940
+    >>> options = mt940.Options(reversal_sign=True, applicant_iban=True)
+    >>> options.reversal_sign, options.strip_bom
+    (True, False)
+    >>> mt940.Options.all().strip_bom
+    True
+"""
+
+from __future__ import annotations
+
+import dataclasses
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class Options:
+    """Switches for behaviour that differs from release 5.0.0.
+
+    Attributes:
+        applicant_iban: File the ``?31`` sub-field of a structured ``:86:``
+            under ``applicant_iban`` instead of prepending it to
+            ``applicant_name`` (issue #132, the 4.x behaviour).
+        merge_keeps_values: A structured ``:86:`` emits ``None`` for every
+            sub-field it does not carry. With this on, such a ``None`` never
+            replaces a value another tag already provided, so the ``:61:``
+            customer reference survives an ``:86:`` without a ``KREF``.
+        reversal_sign: Give the ``:61:`` reversal-of-credit mark ``RC`` a
+            negative amount, like the debit it is (issue #130).
+        case_insensitive_marks: Treat lowercase debit/credit marks (``d``,
+            ``c``, ``rc``, ``rd``) like their uppercase forms when signing an
+            amount. The tag patterns already accept them.
+        timezone_offset: Read the ``:13D:`` offset as hours and minutes, so
+            ``+0100`` is one hour. 5.0.0 read the digits as a minute count.
+        unbounded_details: Keep ``:86:`` details of any length. 5.0.0
+            silently truncated them after nine chunks of 65 characters.
+        non_swift_free_text: Keep the content of ``:NS:`` lines that do not
+            start with a two-digit sub-tag. 5.0.0 replaced such a line with an
+            empty one when it followed a sub-tag line.
+        floor_limit_blank_mark: Treat a blank ``:34F:`` debit/credit mark as
+            "both", giving ``d_floor_limit`` and ``c_floor_limit`` and a
+            statement currency. 5.0.0 produced a key with a leading space.
+        strip_bom: Drop a leading byte-order mark, so the first ``:20:`` tag
+            is recognised. 5.0.0 kept it and lost that tag.
+        gvc_leading_text: Keep free text in front of the first GVC keyword of
+            a ``?20`` purpose when it contains a ``+`` in its first four
+            characters. 5.0.0 dropped that text.
+    """
+
+    applicant_iban: bool = False
+    merge_keeps_values: bool = False
+    reversal_sign: bool = False
+    case_insensitive_marks: bool = False
+    timezone_offset: bool = False
+    unbounded_details: bool = False
+    non_swift_free_text: bool = False
+    floor_limit_blank_mark: bool = False
+    strip_bom: bool = False
+    gvc_leading_text: bool = False
+
+    @classmethod
+    def all(cls) -> Options:
+        """Return an instance with every fix switched on.
+
+        Returns:
+            The options the next major release will use by default.
+        """
+        return cls(**dict.fromkeys(cls.names(), True))
+
+    @classmethod
+    def names(cls) -> tuple[str, ...]:
+        """Return the attribute names, in declaration order.
+
+        Returns:
+            The option names.
+        """
+        return tuple(field.name for field in dataclasses.fields(cls))

--- a/mt940/parser.py
+++ b/mt940/parser.py
@@ -30,16 +30,24 @@ from __future__ import annotations
 import os
 import pathlib
 import re
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Protocol, runtime_checkable
 
 import mt940
+
+from .options import Options
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
 
     from ._types import Processors, Source
     from .models import Transactions
-    from .options import Options
+
+
+@runtime_checkable
+class _Readable(Protocol):
+    """Anything with a ``read()`` method, which is how 5.0.0 spots a handle."""
+
+    def read(self) -> str | bytes: ...
 
 
 def _decode(data: bytes, encoding: str | None) -> str:
@@ -65,41 +73,69 @@ def _decode(data: bytes, encoding: str | None) -> str:
     return data.decode('cp852')
 
 
-def _read(src: Source, encoding: str | None = None) -> str:
+def _load(source: object) -> str | bytes:
+    """Fetch the raw statement data from whatever the caller passed.
+
+    Typed as ``object`` on purpose: the dispatch has to reject whatever
+    arrives at runtime, not only what :data:`~mt940._types.Source` allows.
+    The kinds are recognised the way release 5.0.0 did it: anything with a
+    ``read()`` method is a handle, an ``int`` is a file descriptor, a ``str``
+    or ``bytes`` value that names an existing file is read, and any other
+    ``str`` or ``bytes`` value is the statement data itself.
+
+    Args:
+        source: A file handle, a file descriptor, a path, or raw data.
+
+    Returns:
+        The statement data, still undecoded when it came from bytes.
+
+    Raises:
+        FileNotFoundError: When ``source`` is a path-like object that does
+            not name an existing file.
+        TypeError: When ``source`` is none of the supported kinds.
+    """
+    if isinstance(source, _Readable):
+        return source.read()
+    if isinstance(source, int):
+        # A file descriptor. Reading closes it, as open() did in 5.0.0.
+        with open(source, 'rb') as fh:  # noqa: PTH123, FURB101 (a descriptor)
+            return fh.read()
+    if isinstance(source, (str, bytes, os.PathLike)):
+        if os.path.isfile(source):  # noqa: PTH113 (bytes paths are accepted)
+            return pathlib.Path(os.fsdecode(source)).read_bytes()
+        if isinstance(source, os.PathLike):
+            raise FileNotFoundError(os.fsdecode(source))
+        return source
+    msg = f'unsupported source type {type(source).__name__}'
+    raise TypeError(msg)
+
+
+def _read(
+    src: Source,
+    encoding: str | None = None,
+    *,
+    strip_bom: bool = False,
+) -> str:
     """Read raw mt940 data from a file handle, path or string and decode it.
 
     Args:
-        src: A path, raw ``str``/``bytes`` data or an open file handle. A
-            ``str`` or ``bytes`` value that does not name an existing file
-            is taken to be the statement data itself.
+        src: A file handle, a file descriptor, a path, or raw ``str``/``bytes``
+            data, see :func:`_load`.
         encoding: The encoding to try first for ``bytes`` data.
+        strip_bom: Drop a leading byte-order mark (U+FEFF). It survives
+            decoding as a character that is not whitespace, so it displaces
+            the first ``:20:`` off the start-of-line tag anchor and that
+            tag's data is lost. 5.0.0 kept it, hence the default.
 
     Returns:
-        The decoded statement text without a leading byte-order mark.
-
-    Raises:
-        FileNotFoundError: When ``src`` is a path-like object that does not
-            name an existing file.
+        The decoded statement text.
     """
-    data: str | bytes
-    if not isinstance(src, (str, bytes, os.PathLike)):
-        data = src.read()
-    elif os.path.isfile(src):  # noqa: PTH113 (bytes paths are accepted too)
-        data = pathlib.Path(os.fsdecode(src)).read_bytes()
-    elif isinstance(src, os.PathLike):
-        raise FileNotFoundError(os.fsdecode(src))
-    else:
-        data = src
-
+    data = _load(src)
     if isinstance(data, bytes):
         data = _decode(data, encoding)
-
-    # Strip a leading byte-order mark (U+FEFF). A BOM survives decoding as
-    # U+FEFF for UTF-8 input (and for UTF-16 only when an explicit
-    # utf-16-le/-be encoding is passed). It is not whitespace, so it would
-    # otherwise displace the first `:20:` off the start-of-line tag anchor and
-    # silently drop that tag's data.
-    return data.removeprefix('\ufeff')
+    if strip_bom:
+        data = data.removeprefix('\ufeff')
+    return data
 
 
 def parse(
@@ -129,7 +165,7 @@ def parse(
     Returns:
         The parsed collection of transactions.
     """
-    data = _read(src, encoding)
+    data = _read(src, encoding, strip_bom=(options or Options()).strip_bom)
     transactions = mt940.models.Transactions(
         processors,
         tags,
@@ -179,7 +215,7 @@ def parse_statements(
     Returns:
         One :class:`~mt940.models.Transactions` per statement block.
     """
-    data = _read(src, encoding)
+    data = _read(src, encoding, strip_bom=(options or Options()).strip_bom)
     statements: list[Transactions] = []
     for block in re.split(r'(?m)^(?=:20:)', data):
         if not block.strip().startswith(':20:'):

--- a/mt940/parser.py
+++ b/mt940/parser.py
@@ -39,6 +39,7 @@ if TYPE_CHECKING:
 
     from ._types import Processors, Source
     from .models import Transactions
+    from .options import Options
 
 
 def _decode(data: bytes, encoding: str | None) -> str:
@@ -107,6 +108,8 @@ def parse(
     processors: Processors | None = None,
     tags: dict[int | str, mt940.tags.Tag] | None = None,
     transaction_boundary: Iterable[str] | None = None,
+    *,
+    options: Options | None = None,
 ) -> Transactions:
     """Parse MT940 data into a single :class:`~mt940.models.Transactions`.
 
@@ -120,13 +123,18 @@ def parse(
             a new transaction (issue #110). By default only ``:61:`` starts a
             transaction; pass e.g. ``{'transaction_reference_number'}`` to also
             start one on every ``:20:``. Omit it to keep the legacy behaviour.
+        options: Opt-in behaviours, see :class:`mt940.options.Options`. Omit
+            to parse exactly like release 5.0.0.
 
     Returns:
         The parsed collection of transactions.
     """
     data = _read(src, encoding)
     transactions = mt940.models.Transactions(
-        processors, tags, transaction_boundary=transaction_boundary
+        processors,
+        tags,
+        transaction_boundary=transaction_boundary,
+        options=options,
     )
     _ = transactions.parse(data)
 
@@ -139,6 +147,8 @@ def parse_statements(
     processors: Processors | None = None,
     tags: dict[int | str, mt940.tags.Tag] | None = None,
     transaction_boundary: Iterable[str] | None = None,
+    *,
+    options: Options | None = None,
 ) -> list[Transactions]:
     """Parse an mt940 file that contains multiple statement blocks.
 
@@ -164,6 +174,7 @@ def parse_statements(
         processors: Optional extra pre/post processors (applied per block).
         tags: Optional extra or overriding tag parsers (applied per block).
         transaction_boundary: See :func:`parse` (and the note above).
+        options: See :func:`parse`.
 
     Returns:
         One :class:`~mt940.models.Transactions` per statement block.
@@ -175,7 +186,10 @@ def parse_statements(
             # Drop any leading header / empty chunk before the first :20:.
             continue
         transactions = mt940.models.Transactions(
-            processors, tags, transaction_boundary=transaction_boundary
+            processors,
+            tags,
+            transaction_boundary=transaction_boundary,
+            options=options,
         )
         _ = transactions.parse(block)
         statements.append(transactions)

--- a/mt940/processors.py
+++ b/mt940/processors.py
@@ -17,9 +17,12 @@ import functools
 import re
 from typing import TYPE_CHECKING, Any
 
+# Runtime re-exports: 5.0.0 exposed the processor protocols here.
+from ._types import PostProcessor, PreProcessor  # noqa: TC001
+from .options import Options
+
 if TYPE_CHECKING:
     from . import models, tags
-    from ._types import PostProcessor, PreProcessor
 
 
 def add_currency_pre_processor(
@@ -200,21 +203,26 @@ def mBank_set_tnr(
 
 
 # https://www.db-bankline.deutsche-bank.com/download/MT940_Deutschland_Structure2002.pdf
+#: The structured ``:86:`` sub-fields and the keys they land under, as in
+#: release 5.0.0: ``?31`` is prepended to the name.
 DETAIL_KEYS = {
     '': 'transaction_code',
     '00': 'posting_text',
     '10': 'prima_nota',
     '20': 'purpose',
     '30': 'applicant_bin',
-    # ?31 is the counterparty account, usually an IBAN, sometimes a plain
-    # account number. The field name dates from 4.x and is kept for
-    # compatibility (issue #132). ?32 and ?33 together hold the name.
-    '31': 'applicant_iban',
+    '31': 'applicant_name',
     '32': 'applicant_name',
     '34': 'return_debit_notes',
     '35': 'recipient_name',
     '60': 'additional_purpose',
 }
+
+#: The same mapping with ``?31``, the counterparty account (usually an IBAN,
+#: sometimes a plain account number), under its own key. This is the 4.x
+#: mapping, selected by :attr:`mt940.options.Options.applicant_iban`
+#: (issue #132). ``?32`` and ``?33`` together hold the name.
+DETAIL_KEYS_APPLICANT_IBAN = {**DETAIL_KEYS, '31': 'applicant_iban'}
 
 # https://www.hettwer-beratung.de/sepa-spezialwissen/sepa-technische-anforderungen/sepa-gesch%C3%A4ftsvorfallcodes-gvc-mt-940/
 GVC_KEYS = {
@@ -241,6 +249,22 @@ GVC_KEYS = {
 
 #: Every GVC keyword (``EREF``, ``SVWZ``, ...) is exactly this wide.
 _GVC_KEY_LENGTH = 4
+
+
+def _options_of(transactions: models.Transactions) -> Options:
+    """Return the options of the collection being parsed.
+
+    Callers that pass something without options, as older code did with
+    ``None``, get the 5.0.0 defaults.
+
+    Args:
+        transactions: The collection being parsed.
+
+    Returns:
+        The options to honour.
+    """
+    options: object = getattr(transactions, 'options', None)
+    return options if isinstance(options, Options) else Options()
 
 
 def _parse_segments(detail_str: str) -> collections.OrderedDict[str, str]:
@@ -289,11 +313,14 @@ def _parse_segments(detail_str: str) -> collections.OrderedDict[str, str]:
 
 def _process_segments(
     tmp: collections.OrderedDict[str, str],
+    detail_keys: dict[str, str] = DETAIL_KEYS,
 ) -> dict[str, list[str]]:
     """Process segments into result dictionary.
 
     Args:
         tmp: An OrderedDict of segment types to their content.
+        detail_keys: The sub-field to key mapping, :data:`DETAIL_KEYS` or
+            :data:`DETAIL_KEYS_APPLICANT_IBAN`.
 
     Returns:
         A dictionary mapping keys to lists of segment contents.
@@ -302,10 +329,10 @@ def _process_segments(
         list
     )
     for key, value in tmp.items():
-        if key in DETAIL_KEYS:
-            result[DETAIL_KEYS[key]].append(value)
+        if key in detail_keys:
+            result[detail_keys[key]].append(value)
         elif key == '33':
-            key32 = DETAIL_KEYS['32']
+            key32 = detail_keys['32']
             result[key32].append(value)
         elif key.startswith('2'):
             # Some banks append a bare ' BIC'/' IBAN' label with no value at
@@ -319,10 +346,10 @@ def _process_segments(
                 if purpose.endswith(label):
                     purpose = purpose.removesuffix(label).rstrip()
                     break
-            key20 = DETAIL_KEYS['20']
+            key20 = detail_keys['20']
             result[key20].append(purpose)
         elif key in {'60', '61', '62', '63', '64', '65'}:
-            key60 = DETAIL_KEYS['60']
+            key60 = detail_keys['60']
             result[key60].append(value)
     return result
 
@@ -330,18 +357,20 @@ def _process_segments(
 def _join_result(
     result: dict[str, list[str]],
     space: bool,
+    detail_keys: dict[str, str] = DETAIL_KEYS,
 ) -> dict[str, str | None]:
     """Join result lists into strings.
 
     Args:
         result: The result dictionary with lists of strings.
         space: Whether to include spaces between segments.
+        detail_keys: The mapping whose keys the result must all carry.
 
     Returns:
         A dictionary with joined strings.
     """
     joined_result: dict[str, str | None] = {}
-    for key in DETAIL_KEYS.values():
+    for key in detail_keys.values():
         if space:
             value = ' '.join(result.get(key, []))
         else:
@@ -353,26 +382,37 @@ def _join_result(
 def _parse_mt940_details(
     detail_str: str,
     space: bool = False,
+    *,
+    detail_keys: dict[str, str] = DETAIL_KEYS,
 ) -> dict[str, str | None]:
     """Parse MT940 transaction details.
 
     Args:
         detail_str: The detail string to parse.
         space: Whether to include spaces between segments.
+        detail_keys: The sub-field to key mapping, :data:`DETAIL_KEYS` or
+            :data:`DETAIL_KEYS_APPLICANT_IBAN`.
 
     Returns:
         A dictionary of parsed transaction details.
     """
     tmp = _parse_segments(detail_str)
-    result = _process_segments(tmp)
-    return _join_result(result, space)
+    result = _process_segments(tmp, detail_keys)
+    return _join_result(result, space, detail_keys)
 
 
-def _parse_mt940_gvcodes(purpose: str) -> dict[str, str | None]:
+def _parse_mt940_gvcodes(
+    purpose: str,
+    *,
+    keep_leading_text: bool = False,
+) -> dict[str, str | None]:
     """Parse MT940 GVC codes from the purpose string.
 
     Args:
         purpose: The purpose string to parse.
+        keep_leading_text: Refuse to treat a ``+`` within the first four
+            characters as the end of a GVC keyword, so free text in front of
+            the first keyword survives. Off, 5.0.0 dropped that text.
 
     Returns:
         A dictionary of parsed GVC codes.
@@ -387,13 +427,13 @@ def _parse_mt940_gvcodes(purpose: str) -> dict[str, str | None]:
         # Detect the beginning of a GVC segment: if a '+' is encountered
         # and the four characters preceding it form a valid GVC key. GVC
         # keywords are four characters wide, so a '+' before index 4 cannot
-        # terminate one; guarding on the index also avoids a negative
-        # ``purpose[index - 4:index]`` slice wrapping to the empty string
-        # (which spuriously matched the empty-string GVC key and truncated a
-        # literal '+' in the leading free text).
+        # terminate one. Without the guard a negative
+        # ``purpose[index - 4:index]`` slice wraps to the empty string, which
+        # matches the empty-string GVC key and drops the text in front of a
+        # literal '+'. That is what 5.0.0 did.
         if (
             char == '+'
-            and index >= _GVC_KEY_LENGTH
+            and (index >= _GVC_KEY_LENGTH or not keep_leading_text)
             and purpose[index - _GVC_KEY_LENGTH : index] in GVC_KEYS
         ):
             if segment_type:
@@ -439,17 +479,28 @@ def transaction_details_post_processor(
     Returns:
         The updated result dictionary.
     """
+    options = _options_of(transactions)
+    detail_keys = (
+        DETAIL_KEYS_APPLICANT_IBAN if options.applicant_iban else DETAIL_KEYS
+    )
     details = tag_dict['transaction_details']
     details = ''.join(detail.strip('\n\r') for detail in details.splitlines())
 
     # check for e.g. 103?00...
     if re.match(r'^\d{3}\?\d{2}', details):
-        result.update(_parse_mt940_details(details, space=space))
+        result.update(
+            _parse_mt940_details(details, space=space, detail_keys=detail_keys)
+        )
 
         purpose = result.get('purpose')
 
         if purpose and any(gvk in purpose for gvk in GVC_KEYS if gvk):
-            result.update(_parse_mt940_gvcodes(result['purpose']))
+            result.update(
+                _parse_mt940_gvcodes(
+                    result['purpose'],
+                    keep_leading_text=options.gvc_leading_text,
+                )
+            )
 
         # Clean up the purpose field
         if result.get('purpose'):

--- a/mt940/tags.py
+++ b/mt940/tags.py
@@ -81,6 +81,7 @@ import typing
 from typing import TYPE_CHECKING, ClassVar
 
 from . import models
+from .options import Options
 
 if TYPE_CHECKING:
     from typing_extensions import Self
@@ -90,6 +91,29 @@ logger = logging.getLogger(__name__)
 #: An entry date more than this many days away from the value date means the
 #: two fall in different years, so the entry date's year needs correcting.
 _YEAR_BOUNDARY_DAYS = 330
+
+#: What 5.0.0 captured of a ``:86:`` value: up to nine chunks of at most 65
+#: characters, each but the last optionally followed by a line break. Longer
+#: details were silently cut off. The pattern accepts the empty string, so it
+#: always matches.
+_LEGACY_DETAILS_RE = re.compile(r'(?:[\s\S]{0,65}\r?\n?){0,8}[\s\S]{0,65}')
+
+
+def _options_of(transactions: models.Transactions) -> Options:
+    """Return the options of the collection being parsed.
+
+    Tags are shared singletons, so the switches always come from
+    ``transactions``. Callers that pass something without options, as older
+    code did with ``None``, get the 5.0.0 defaults.
+
+    Args:
+        transactions: The collection being parsed.
+
+    Returns:
+        The options to honour.
+    """
+    options: object = getattr(transactions, 'options', None)
+    return options if isinstance(options, Options) else Options()
 
 
 class Tag:
@@ -210,17 +234,14 @@ class Tag:
         return object.__new__(cls)
 
     def __eq__(self, other: object) -> bool:
-        """Return whether ``other`` is a tag of the same class and ``id``.
+        """Return whether ``other`` is this very tag instance.
 
-        Tags carry no instance state beyond what their class defines, so two
-        instances of one class are interchangeable, which is what
-        ``__hash__`` already assumes.
+        Tags compare by identity, as they did in 5.0.0, so two instances of
+        one class stay distinct set members and dictionary keys. The
+        id-based ``__hash__`` is consistent with that: an object is always
+        equal to itself.
         """
-        return (
-            isinstance(other, Tag)
-            and type(other) is type(self)
-            and other.id == self.id
-        )
+        return self is other
 
     def __hash__(self) -> int:
         """Return a hash based on the tag's ``id``.
@@ -252,17 +273,19 @@ class DateTimeIndication(Tag):
     ) -> dict[str, object]:
         """Return the report :class:`~mt940.models.DateTime` as ``date``."""
         data = super().__call__(transactions, value)
-        # The offset subfield is a signed HHMM value (e.g. +0130 is 1 hour
-        # and 30 minutes east of UTC), while `models.DateTime` expects the
-        # offset as a number of minutes. Convert it here and drop the raw
-        # groups so they are not passed on when the offset is absent.
+        # Drop the raw groups so they are not passed on when the offset is
+        # absent, which then yields a naive datetime.
         sign: str | None = data.pop('offset_sign', None)
         offset: str | None = data.pop('offset', None)
-        if offset:
+        if offset and _options_of(transactions).timezone_offset:
+            # The subfield is a signed HHMM value: +0130 is one hour and
+            # thirty minutes east of UTC, and models.DateTime wants minutes.
             minutes: int = int(offset[:2]) * 60 + int(offset[2:])
-            if sign == '-':
-                minutes = -minutes
-            data['offset'] = minutes
+            data['offset'] = -minutes if sign == '-' else minutes
+        elif offset:
+            # 5.0.0 handed the digits to FixedOffset as a minute count, so
+            # +0100 became 100 minutes with '0100' as the zone name.
+            data['offset'] = f'-{offset}' if sign == '-' else offset
         return {'date': models.DateTime(**data)}
 
 
@@ -329,25 +352,32 @@ class FloorLimitIndicator(Tag):
     ) -> dict[str, object]:
         """Return the floor limit as ``d_floor_limit``/``c_floor_limit``."""
         data = typing.cast(
-            'dict[str, str]',
+            'dict[str, str | None]',
             super().__call__(transactions, value),
         )
-        # Normalize the D/C mark: a space (sent by e.g. Fiducia/Volksbank,
-        # d36c51b) means "both", like an absent mark, and a lowercase mark
-        # (the patterns match case-insensitively) must behave like its
-        # uppercase form so the debit amount is negated consistently.
-        status: str = data['status'].strip().upper()
+        options = _options_of(transactions)
+        # A missing mark counts as absent, as it did in 5.0.0.
+        status: str = data.get('status') or ''
+        if options.floor_limit_blank_mark:
+            # A space (sent by e.g. Fiducia/Volksbank, d36c51b) means
+            # "both", like an absent mark. Without the option it survives
+            # into the key, as ' _floor_limit'. The sign of a lowercase mark
+            # is Amount's business, through case_insensitive_marks.
+            status = status.strip()
+        amount: str = data.get('amount') or ''
+        currency = data.get('currency')
         if status:
-            data['status'] = status
             key: str = status.lower() + '_floor_limit'
-            return {key: models.Amount(**data)}
-        data_d = data.copy()
-        data_c = data.copy()
-        data_d.update({'status': 'D'})
-        data_c.update({'status': 'C'})
+            return {
+                key: models.Amount(amount, status, currency, options=options)
+            }
         return {
-            'd_floor_limit': models.Amount(**data_d),
-            'c_floor_limit': models.Amount(**data_c),
+            'd_floor_limit': models.Amount(
+                amount, 'D', currency, options=options
+            ),
+            'c_floor_limit': models.Amount(
+                amount, 'C', currency, options=options
+            ),
         }
 
 
@@ -386,8 +416,7 @@ class NonSwift(Tag):
         self, transactions: models.Transactions, value: dict[str, typing.Any]
     ) -> dict[str, object]:
         """Return ``value`` with per-line ``non_swift_<id>`` fields added."""
-        # Part of the tag protocol, the non-swift data needs no context.
-        del transactions
+        keep_free_text = _options_of(transactions).non_swift_free_text
         text: list[str] = []
         data = value['non_swift']
         for line in data.split('\n'):
@@ -396,13 +425,18 @@ class NonSwift(Tag):
                 ns = frag.groupdict()
                 value['non_swift_' + ns['ns_id']] = ns['ns_data']
                 text.append(ns['ns_data'])
-            elif line.strip():
+            elif keep_free_text and line.strip():
                 # Free-form line without a two-digit sub-tag: keep the
                 # content instead of dropping it.
                 text.append(line.strip())
             elif text and text[-1]:
-                # Blank line: collapse runs into one paragraph separator.
+                # Blank line, or in 5.0.0 any line without a sub-tag after
+                # content: collapse runs into one paragraph separator.
                 text.append('')
+            elif line.strip():
+                # 5.0.0 kept a free-form line only at the start of the text
+                # or after a separator.
+                text.append(line.strip())
         value['non_swift_text'] = '\n'.join(text)
         value['non_swift'] = data
         return value
@@ -428,9 +462,10 @@ class BalanceBase(Tag):
     ) -> dict[str, object]:
         """Return a :class:`~mt940.models.Balance` under the tag's slug."""
         data = super().__call__(transactions, value)
-        data['amount'] = models.Amount(**data)
+        options = _options_of(transactions)
+        data['amount'] = models.Amount(**data, options=options)
         data['date'] = models.Date(**data)
-        return {self.slug: models.Balance(**data)}
+        return {self.slug: models.Balance(**data, options=options)}
 
 
 class OpeningBalance(BalanceBase):
@@ -513,7 +548,9 @@ class Statement(Tag):
         """Return the data with the amount and dates built."""
         data = super().__call__(transactions, value)
         data.setdefault('currency', transactions.currency)
-        data['amount'] = models.Amount(**data)
+        data['amount'] = models.Amount(
+            **data, options=_options_of(transactions)
+        )
         date = data['date'] = models.Date(**data)
 
         entry_day = str(data.get('entry_day') or '')
@@ -584,6 +621,12 @@ class StatementASNB(Statement):
     (//(?P<bank_reference>.{0,16}))?
     (\n?(?P<extra_details>.{0,34}))?
     $"""
+
+    def __call__(
+        self, transactions: models.Transactions, value: dict[str, typing.Any]
+    ) -> dict[str, object]:
+        """Return the statement data, built exactly like :class:`Statement`."""
+        return super().__call__(transactions, value)
 
 
 class StatementGLS(Statement):
@@ -662,13 +705,32 @@ class TransactionDetails(Tag):
         models.Transaction
     )
     # The SWIFT spec caps this field at 6 lines of 65 characters, but many
-    # banks send more. A previous cap of nine 65-char chunks silently
-    # truncated anything longer, so the capture is unbounded: the parser in
+    # banks send more. The capture is unbounded: the parser in
     # `models.Transactions.parse` already limits the value to this tag's own
-    # slice of the statement.
+    # slice of the statement. `parse` below applies the 5.0.0 cap of nine
+    # 65-character chunks unless `Options.unbounded_details` is on.
     pattern: ClassVar[str] = r"""
     (?P<transaction_details>[\s\S]*)
     """
+
+    def parse(
+        self, transactions: models.Transactions, value: str
+    ) -> dict[str, str | None]:
+        """Capture the details, cut like 5.0.0 did unless opted out.
+
+        Args:
+            transactions: The collection being parsed, for its options.
+            value: The raw tag value.
+
+        Returns:
+            The ``transaction_details`` group.
+        """
+        data = super().parse(transactions, value)
+        if not _options_of(transactions).unbounded_details:
+            details = data['transaction_details'] or ''
+            match = _LEGACY_DETAILS_RE.match(details)
+            data['transaction_details'] = match.group(0) if match else ''
+        return data
 
 
 class SumEntries(Tag):
@@ -688,7 +750,11 @@ class SumEntries(Tag):
         """Return a :class:`~mt940.models.SumAmount` under the tag's slug."""
         data = super().__call__(transactions, value)
         data['status'] = self.status
-        return {self.slug: models.SumAmount(**data)}
+        return {
+            self.slug: models.SumAmount(
+                **data, options=_options_of(transactions)
+            )
+        }
 
 
 class SumDebitEntries(SumEntries):

--- a/mt940_tests/betterplace/amount_formats.yml
+++ b/mt940_tests/betterplace/amount_formats.yml
@@ -9,6 +9,18 @@ data:
     - !!binary |
       B9oDEg==
     status: C
+options: !!python/object/new:mt940.options.Options
+  state:
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
 tags:
   13: !!python/object:mt940.tags.DateTimeIndication
     re: !!python/object/apply:re._compile

--- a/mt940_tests/betterplace/currency_in_25.yml
+++ b/mt940_tests/betterplace/currency_in_25.yml
@@ -1,6 +1,18 @@
 !!python/object:mt940.models.Transactions
 data:
   account_identification: 51210600/9223382012EUR
+options: !!python/object/new:mt940.options.Options
+  state:
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
 tags:
   13: !!python/object:mt940.tags.DateTimeIndication
     re: !!python/object/apply:re._compile

--- a/mt940_tests/betterplace/empty_86.yml
+++ b/mt940_tests/betterplace/empty_86.yml
@@ -1,5 +1,17 @@
 !!python/object:mt940.models.Transactions
 data: {}
+options: !!python/object/new:mt940.options.Options
+  state:
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
 tags:
   13: !!python/object:mt940.tags.DateTimeIndication
     re: !!python/object/apply:re._compile

--- a/mt940_tests/betterplace/empty_entry_date.yml
+++ b/mt940_tests/betterplace/empty_entry_date.yml
@@ -1,5 +1,17 @@
 &id003 !!python/object:mt940.models.Transactions
 data: {}
+options: !!python/object/new:mt940.options.Options
+  state:
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
 tags:
   13: !!python/object:mt940.tags.DateTimeIndication
     re: !!python/object/apply:re._compile

--- a/mt940_tests/betterplace/empty_line.yml
+++ b/mt940_tests/betterplace/empty_line.yml
@@ -1,6 +1,18 @@
 !!python/object:mt940.models.Transactions
 data:
   transaction_reference: TELEREPORTING
+options: !!python/object/new:mt940.options.Options
+  state:
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
 tags:
   13: !!python/object:mt940.tags.DateTimeIndication
     re: !!python/object/apply:re._compile

--- a/mt940_tests/betterplace/missing_crlf_at_end.yml
+++ b/mt940_tests/betterplace/missing_crlf_at_end.yml
@@ -9,6 +9,18 @@ data:
     - !!binary |
       B9oDFw==
     status: C
+options: !!python/object/new:mt940.options.Options
+  state:
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
 tags:
   13: !!python/object:mt940.tags.DateTimeIndication
     re: !!python/object/apply:re._compile

--- a/mt940_tests/betterplace/sepa_mt9401.all.yml
+++ b/mt940_tests/betterplace/sepa_mt9401.all.yml
@@ -1,0 +1,4723 @@
+&id004 !!python/object:mt940.models.Transactions
+data:
+  account_identification: 50880050/0194804000888
+  available_balance: !!python/object:mt940.models.Balance
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '50.05'
+      currency: EUR
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    status: C
+  final_closing_balance: !!python/object:mt940.models.Balance
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '50.05'
+      currency: EUR
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    status: C
+  final_opening_balance: !!python/object:mt940.models.Balance
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '0'
+      currency: EUR
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cIFg==
+    status: C
+  intermediate_closing_balance: !!python/object:mt940.models.Balance
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '-3814901.47'
+      currency: EUR
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    status: D
+  intermediate_opening_balance: !!python/object:mt940.models.Balance
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '-3814901.47'
+      currency: EUR
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    status: D
+  sequence_number: '00001'
+  statement_number: '00001'
+  transaction_reference: T089414136000001
+options: !!python/object/new:mt940.options.Options
+  state:
+  - true
+  - true
+  - true
+  - true
+  - true
+  - true
+  - true
+  - true
+  - true
+  - true
+tags:
+  13: !!python/object:mt940.tags.DateTimeIndication
+    re: !!python/object/apply:re._compile
+    - "^\n    (?P<year>\\d{2})\n    (?P<month>\\d{2})\n    (?P<day>\\d{2})\n    (?P<hour>\\\
+      d{2})\n    (?P<minute>\\d{2})\n    ((?P<offset_sign>[+-])(?P<offset>\\d{4}))?\n\
+      \    "
+    - 98
+  20: !!python/object:mt940.tags.TransactionReferenceNumber
+    re: !!python/object/apply:re._compile
+    - (?P<transaction_reference>.{0,16})
+    - 98
+  21: !!python/object:mt940.tags.RelatedReference
+    re: !!python/object/apply:re._compile
+    - (?P<related_reference>.{0,16})
+    - 98
+  25: !!python/object:mt940.tags.AccountIdentification
+    re: !!python/object/apply:re._compile
+    - (?P<account_identification>.{0,35})
+    - 98
+  28: !!python/object:mt940.tags.StatementNumber
+    re: !!python/object/apply:re._compile
+    - "\n    (?P<statement_number>\\d{1,5})  # 5n\n    (?:/?(?P<sequence_number>\\\
+      d{1,5}))?  # [/5n]\n    $"
+    - 98
+  60: !!python/object:mt940.tags.OpeningBalance
+    re: &id001 !!python/object/apply:re._compile
+    - "^\n    (?P<status>[DC])  # 1!a Debit/Credit\n    (?P<year>\\d{2})  # 6!n Value\
+      \ Date (YYMMDD)\n    (?P<month>\\d{2})\n    (?P<day>\\d{2})\n    (?P<currency>.{3})\
+      \  # 3!a Currency\n    (?P<amount>[0-9,]{0,16})  # 15d Amount (includes decimal\
+      \ sign, so 16)\n    "
+    - 98
+  60M: !!python/object:mt940.tags.IntermediateOpeningBalance
+    re: *id001
+  60F: !!python/object:mt940.tags.FinalOpeningBalance
+    re: *id001
+  61: !!python/object:mt940.tags.Statement
+    re: !!python/object/apply:re._compile
+    - "^\n    (?P<year>\\d{2})  # 6!n Value Date (YYMMDD)\n    (?P<month>\\d{2})\n\
+      \    (?P<day>\\d{2})\n    (?P<entry_month>\\d{2}|\\s{2})?  # [4!n] Entry Date\
+      \ (MMDD)\n    (?P<entry_day>\\d{2}|\\s{2})?\n    (?P<status>R?[DC])  # 2a Debit/Credit\
+      \ Mark\n    (?P<funds_code>[A-Z])? # [1!a] Funds Code (3rd character of the\
+      \ currency\n                            # code, if needed)\n    [\\n ]?\n  \
+      \  (?P<amount>[\\d,]{1,15})  # 15d Amount\n    (?P<id>[A-Z][A-Z0-9 ]{3})?\n\
+      \    (?P<customer_reference>((?!//)[^\\n]){0,16})\n    (//(?P<bank_reference>.{0,23}))?\n\
+      \    # Supplementary details: the SWIFT spec caps this at 34x, but some banks\n\
+      \    # (e.g. Wise, issue #117) send more, so the length limit is relaxed. This\n\
+      \    # only ever turns a previous parse error into a successful parse.\n   \
+      \ (\\n?(?P<extra_details>.*))?\n    $"
+    - 98
+  62: !!python/object:mt940.tags.ClosingBalance
+    re: *id001
+  62M: !!python/object:mt940.tags.IntermediateClosingBalance
+    re: *id001
+  62F: !!python/object:mt940.tags.FinalClosingBalance
+    re: *id001
+  64: !!python/object:mt940.tags.AvailableBalance
+    re: *id001
+  65: !!python/object:mt940.tags.ForwardAvailableBalance
+    re: *id001
+  86: !!python/object:mt940.tags.TransactionDetails
+    re: !!python/object/apply:re._compile
+    - "\n    (?P<transaction_details>[\\s\\S]*)\n    "
+    - 98
+  34: !!python/object:mt940.tags.FloorLimitIndicator
+    re: !!python/object/apply:re._compile
+    - "^\n    (?P<currency>[A-Z]{3})  # 3!a Currency\n    (?P<status>[DC ]?)  # 2a\
+      \ Debit/Credit Mark\n    (?P<amount>[0-9,]{0,16})  # 15d Amount (includes decimal\
+      \ sign, so 16)\n    $"
+    - 98
+  NS: !!python/object:mt940.tags.NonSwift
+    re: !!python/object/apply:re._compile
+    - "\n    (?P<non_swift>[\\s\\S]*)\n    $"
+    - 98
+  90: !!python/object:mt940.tags.SumEntries
+    re: &id002 !!python/object/apply:re._compile
+    - "^\n    (?P<number>\\d*)\n    (?P<currency>.{3})  # 3!a Currency\n    (?P<amount>[\\\
+      d,]{1,15})  # 15d Amount\n    "
+    - 98
+  90D: !!python/object:mt940.tags.SumDebitEntries
+    re: *id002
+  90C: !!python/object:mt940.tags.SumCreditEntries
+    re: *id002
+transaction_boundary: !!python/object/apply:builtins.frozenset
+- []
+transactions:
+- !!python/object:mt940.models.Transaction
+  data:
+    FRST_ONE_OFF_RECC: null
+    additional_position_date: null
+    additional_position_reference: null
+    additional_purpose: null
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '300'
+      currency: EUR
+    applicant_bin: null
+    applicant_creditor_id: null
+    applicant_iban: null
+    applicant_name: null
+    bank_reference: 0724710345313905
+    compensation_amount: null
+    currency: EUR
+    customer_reference: TFNr 40005 MSGID
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    debitor_identifier: null
+    deviate_applicant: null
+    deviate_recipient: null
+    end_to_end_reference: TFNR 40005 00005MTLG:Grund nicht spezifiziert Reject aus
+      SEPA-Ueberweisungsauftrag
+    entry_date: &id003 !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    extra_details: ''
+    funds_code: R
+    guessed_entry_date: *id003
+    gvc_applicant_bin: null
+    gvc_applicant_iban: null
+    id: NTRF
+    old_SEPA_CI: null
+    old_SEPA_additional_position_reference: null
+    original_amount: null
+    posting_text: RETOURE
+    prima_nota: 0399
+    purpose: null
+    purpose_code: null
+    recipient_name: null
+    return_debit_notes: '914'
+    settlement_tag: null
+    status: C
+    transaction_code: '159'
+    transaction_reference: T089413946000001
+  transactions: *id004
+- !!python/object:mt940.models.Transaction
+  data:
+    FRST_ONE_OFF_RECC: null
+    additional_position_date: null
+    additional_position_reference: null
+    additional_purpose: null
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '335.33'
+      currency: EUR
+    applicant_bin: null
+    applicant_creditor_id: null
+    applicant_iban: null
+    applicant_name: null
+    bank_reference: 0724710351061491
+    compensation_amount: null
+    currency: EUR
+    customer_reference: TFNr 44003 MSGID
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    debitor_identifier: null
+    deviate_applicant: null
+    deviate_recipient: null
+    end_to_end_reference: TFNR 44003 00001MTLG:Grund nicht spezifiziert Reject aus
+      SEPA-Ueberweisungsauftrag
+    entry_date: &id005 !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    extra_details: ''
+    funds_code: R
+    guessed_entry_date: *id005
+    gvc_applicant_bin: null
+    gvc_applicant_iban: null
+    id: NTRF
+    old_SEPA_CI: null
+    old_SEPA_additional_position_reference: null
+    original_amount: null
+    posting_text: RETOURE
+    prima_nota: 0399
+    purpose: null
+    purpose_code: null
+    recipient_name: null
+    return_debit_notes: '914'
+    settlement_tag: null
+    status: C
+    transaction_code: '159'
+    transaction_reference: T089413946000001
+  transactions: *id004
+- !!python/object:mt940.models.Transaction
+  data:
+    FRST_ONE_OFF_RECC: null
+    additional_position_date: null
+    additional_position_reference: null
+    additional_purpose: null
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '15000'
+      currency: EUR
+    applicant_bin: null
+    applicant_creditor_id: null
+    applicant_iban: null
+    applicant_name: null
+    bank_reference: 0724710345313900
+    compensation_amount: null
+    currency: EUR
+    customer_reference: TFNr 40005 MSGID
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    debitor_identifier: null
+    deviate_applicant: null
+    deviate_recipient: null
+    end_to_end_reference: TFNR 40005 00002MTLG:Grund nicht spezifiziert Reject aus
+      SEPA-Ueberweisungsauftrag
+    entry_date: &id006 !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    extra_details: ''
+    funds_code: R
+    guessed_entry_date: *id006
+    gvc_applicant_bin: null
+    gvc_applicant_iban: null
+    id: NTRF
+    old_SEPA_CI: null
+    old_SEPA_additional_position_reference: null
+    original_amount: null
+    posting_text: RETOURE
+    prima_nota: 0399
+    purpose: null
+    purpose_code: null
+    recipient_name: null
+    return_debit_notes: '914'
+    settlement_tag: null
+    status: C
+    transaction_code: '159'
+    transaction_reference: T089413946000001
+  transactions: *id004
+- !!python/object:mt940.models.Transaction
+  data:
+    additional_purpose: null
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '66295.08'
+      currency: EUR
+    applicant_bin: null
+    applicant_iban: null
+    applicant_name: null
+    bank_reference: null
+    currency: EUR
+    customer_reference: NONREF
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    entry_date: &id007 !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    extra_details: ''
+    funds_code: R
+    guessed_entry_date: *id007
+    id: NMSC
+    posting_text: SAMMLER
+    prima_nota: '9800'
+    purpose: 0904059001
+    recipient_name: null
+    return_debit_notes: null
+    status: C
+    transaction_code: 079
+    transaction_reference: T089413946000001
+  transactions: *id004
+- !!python/object:mt940.models.Transaction
+  data:
+    FRST_ONE_OFF_RECC: null
+    additional_position_date: null
+    additional_position_reference: null
+    additional_purpose: null
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '915311.55'
+      currency: EUR
+    applicant_bin: null
+    applicant_creditor_id: null
+    applicant_iban: null
+    applicant_name: null
+    bank_reference: R724710351061495
+    compensation_amount: null
+    currency: EUR
+    customer_reference: TFNr 44003 MSGID
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    debitor_identifier: null
+    deviate_applicant: null
+    deviate_recipient: null
+    end_to_end_reference: TFNR 44003 00002MTLG:Konto gesperrt Rueckueberweisung aus
+      SEPA-Ueberweisungsauftrag
+    entry_date: &id008 !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    extra_details: ''
+    funds_code: R
+    guessed_entry_date: *id008
+    gvc_applicant_bin: null
+    gvc_applicant_iban: null
+    id: NTRF
+    old_SEPA_CI: null
+    old_SEPA_additional_position_reference: null
+    original_amount: null
+    posting_text: RETOURE
+    prima_nota: 0399
+    purpose: null
+    purpose_code: null
+    recipient_name: null
+    return_debit_notes: '903'
+    settlement_tag: null
+    status: C
+    transaction_code: '159'
+    transaction_reference: T089413946000001
+  transactions: *id004
+- !!python/object:mt940.models.Transaction
+  data:
+    additional_purpose: null
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '-204.88'
+      currency: EUR
+    applicant_bin: null
+    applicant_iban: null
+    applicant_name: null
+    bank_reference: null
+    currency: EUR
+    customer_reference: NONREF
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    entry_date: &id009 !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    extra_details: ''
+    funds_code: R
+    guessed_entry_date: *id009
+    id: NRTI
+    posting_text: SAMMLER/STORNO
+    prima_nota: '9800'
+    purpose: 0904059003
+    recipient_name: null
+    return_debit_notes: null
+    status: RC
+    transaction_code: 079
+    transaction_reference: T089413946000001
+  transactions: *id004
+- !!python/object:mt940.models.Transaction
+  data:
+    additional_purpose: null
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '-999946.95'
+      currency: EUR
+    applicant_bin: null
+    applicant_iban: null
+    applicant_name: null
+    bank_reference: null
+    currency: EUR
+    customer_reference: NONREF
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    entry_date: &id010 !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    extra_details: ''
+    funds_code: R
+    guessed_entry_date: *id010
+    id: NMSC
+    posting_text: SAMMLER
+    prima_nota: '9800'
+    purpose: 0904059002
+    recipient_name: null
+    return_debit_notes: null
+    status: D
+    transaction_code: 079
+    transaction_reference: T089413946000001
+  transactions: *id004
+- !!python/object:mt940.models.Transaction
+  data:
+    FRST_ONE_OFF_RECC: null
+    additional_position_date: null
+    additional_position_reference: null
+    additional_purpose: enat
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '15000.05'
+      currency: EUR
+    applicant_bin: PBNKDEFF100
+    applicant_creditor_id: null
+    applicant_iban: DE42100100100043921105
+    applicant_name: Richter Renate 70 Zeichen Beginn Fuellzeichen xxxxxxxx
+    bank_reference: 0724710290621954
+    compensation_amount: null
+    currency: EUR
+    customer_reference: NONREF
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    debitor_identifier: null
+    deviate_applicant: null
+    deviate_recipient: null
+    end_to_end_reference: EndToEndIdTFNR2000400001
+    entry_date: &id011 !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    extra_details: ''
+    funds_code: R
+    guessed_entry_date: *id011
+    gvc_applicant_bin: null
+    gvc_applicant_iban: null
+    id: NTRF
+    old_SEPA_CI: null
+    old_SEPA_additional_position_reference: null
+    original_amount: null
+    posting_text: GUTSCHRIFT
+    prima_nota: 0399
+    purpose: 'TO 13 TFNr 20004 Eingangskanal Mint ..........................................  ...........................................................MTLG:SEPA-Ueberweisungseingang
+      Auftraggeber: Richter R'
+    purpose_code: null
+    recipient_name: null
+    return_debit_notes: null
+    settlement_tag: null
+    status: C
+    transaction_code: '166'
+    transaction_reference: T089413956000001
+  transactions: *id004
+- !!python/object:mt940.models.Transaction
+  data:
+    FRST_ONE_OFF_RECC: null
+    additional_position_date: null
+    additional_position_reference: null
+    additional_purpose: null
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '-500250'
+      currency: EUR
+    applicant_bin: null
+    applicant_creditor_id: null
+    applicant_iban: null
+    applicant_name: null
+    bank_reference: BD7CFA74485E7E69
+    compensation_amount: null
+    currency: EUR
+    customer_reference: 'KREF+
+
+      TFNr 01005 PayId CTSc-01 EBBMTLG:SEPA-Ueberweisungsauftrag Datei mit 0000005
+      Zahlungen'
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    debitor_identifier: null
+    deviate_applicant: null
+    deviate_recipient: null
+    end_to_end_reference: null
+    entry_date: &id012 !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    extra_details: ''
+    funds_code: R
+    guessed_entry_date: *id012
+    gvc_applicant_bin: null
+    gvc_applicant_iban: null
+    id: NTRF
+    old_SEPA_CI: null
+    old_SEPA_additional_position_reference: null
+    original_amount: null
+    posting_text: SEPA-UEBERW
+    prima_nota: 0399
+    purpose: null
+    purpose_code: null
+    recipient_name: null
+    return_debit_notes: null
+    settlement_tag: null
+    status: D
+    transaction_code: '191'
+    transaction_reference: T089413956000001
+  transactions: *id004
+- !!python/object:mt940.models.Transaction
+  data:
+    FRST_ONE_OFF_RECC: null
+    additional_position_date: null
+    additional_position_reference: null
+    additional_purpose: null
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '50.05'
+      currency: EUR
+    applicant_bin: PBNKDEFF100
+    applicant_creditor_id: null
+    applicant_iban: DE42100100100043921105
+    applicant_name: Richter Renate 70 Zeichen Beginn Fuellzeichenxxxxxxxx
+    bank_reference: 0724710290658244
+    compensation_amount: null
+    currency: EUR
+    customer_reference: NONREF
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    debitor_identifier: null
+    deviate_applicant: null
+    deviate_recipient: null
+    end_to_end_reference: EndToEndIdTFNR5200100001
+    entry_date: &id013 !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    extra_details: ''
+    funds_code: R
+    guessed_entry_date: *id013
+    gvc_applicant_bin: null
+    gvc_applicant_iban: null
+    id: NTRF
+    old_SEPA_CI: null
+    old_SEPA_additional_position_reference: null
+    original_amount: null
+    posting_text: GUTSCHRIFT
+    prima_nota: 0399
+    purpose: 'Keine Buchung zu: TO13 TF52001 MINT'
+    purpose_code: null
+    recipient_name: null
+    return_debit_notes: null
+    settlement_tag: null
+    status: C
+    transaction_code: '166'
+    transaction_reference: T089413966000001
+  transactions: *id004
+- !!python/object:mt940.models.Transaction
+  data:
+    FRST_ONE_OFF_RECC: null
+    additional_position_date: null
+    additional_position_reference: null
+    additional_purpose: null
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '125.88'
+      currency: EUR
+    applicant_bin: NIKACH22XXX
+    applicant_creditor_id: null
+    applicant_iban: CH8500779014054431109
+    applicant_name: Cornelia Prochownik 70 Zeichen BeginnFuellzeichen xxx
+    bank_reference: 0724710290635078
+    compensation_amount: null
+    currency: EUR
+    customer_reference: NONREF
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    debitor_identifier: null
+    deviate_applicant: null
+    deviate_recipient: null
+    end_to_end_reference: null
+    entry_date: &id014 !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    extra_details: ''
+    funds_code: R
+    guessed_entry_date: *id014
+    gvc_applicant_bin: null
+    gvc_applicant_iban: null
+    id: NTRF
+    old_SEPA_CI: null
+    old_SEPA_additional_position_reference: null
+    original_amount: null
+    posting_text: GUTSCHRIFT
+    prima_nota: 0399
+    purpose: TO13 TF20018 MINT
+    purpose_code: null
+    recipient_name: null
+    return_debit_notes: null
+    settlement_tag: null
+    status: C
+    transaction_code: '166'
+    transaction_reference: T089413966000001
+  transactions: *id004
+- !!python/object:mt940.models.Transaction
+  data:
+    FRST_ONE_OFF_RECC: null
+    additional_position_date: null
+    additional_position_reference: null
+    additional_purpose: null
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '125004.88'
+      currency: EUR
+    applicant_bin: UBSWCHZH80A
+    applicant_creditor_id: null
+    applicant_iban: CH6500279279C31180700
+    applicant_name: Richter Renate 70 Zeichen Beginn Fuellzeichen xxxxxxxx
+    bank_reference: 0724710290626371
+    compensation_amount: null
+    currency: EUR
+    customer_reference: NONREF
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    debitor_identifier: null
+    deviate_applicant: null
+    deviate_recipient: null
+    end_to_end_reference: null
+    entry_date: &id015 !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    extra_details: ''
+    funds_code: R
+    guessed_entry_date: *id015
+    gvc_applicant_bin: null
+    gvc_applicant_iban: null
+    id: NTRF
+    old_SEPA_CI: null
+    old_SEPA_additional_position_reference: null
+    original_amount: null
+    posting_text: GUTSCHRIFT
+    prima_nota: 0399
+    purpose: TO13 TF20008 MINTMTLG:Ggf.Meldevorschriften beachten
+    purpose_code: null
+    recipient_name: null
+    return_debit_notes: null
+    settlement_tag: null
+    status: C
+    transaction_code: '166'
+    transaction_reference: T089413966000001
+  transactions: *id004
+- !!python/object:mt940.models.Transaction
+  data:
+    FRST_ONE_OFF_RECC: null
+    additional_position_date: null
+    additional_position_reference: null
+    additional_purpose: null
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '-326609.66'
+      currency: EUR
+    applicant_bin: null
+    applicant_creditor_id: null
+    applicant_iban: null
+    applicant_name: null
+    bank_reference: DE85920B84F8E98D
+    compensation_amount: null
+    currency: EUR
+    customer_reference: 'KREF+
+
+      TFNr 01007 PayId CTSc-01 EBBMTLG:SEPA-Ueberweisungsauftrag Datei mit 0000006
+      Zahlungen'
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    debitor_identifier: null
+    deviate_applicant: null
+    deviate_recipient: null
+    end_to_end_reference: null
+    entry_date: &id016 !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    extra_details: ''
+    funds_code: R
+    guessed_entry_date: *id016
+    gvc_applicant_bin: null
+    gvc_applicant_iban: null
+    id: NTRF
+    old_SEPA_CI: null
+    old_SEPA_additional_position_reference: null
+    original_amount: null
+    posting_text: SEPA-UEBERW
+    prima_nota: 0399
+    purpose: null
+    purpose_code: null
+    recipient_name: null
+    return_debit_notes: null
+    settlement_tag: null
+    status: D
+    transaction_code: '191'
+    transaction_reference: T089413966000001
+  transactions: *id004
+- !!python/object:mt940.models.Transaction
+  data:
+    FRST_ONE_OFF_RECC: null
+    additional_position_date: null
+    additional_position_reference: null
+    additional_purpose: null
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '-326609.66'
+      currency: EUR
+    applicant_bin: null
+    applicant_creditor_id: null
+    applicant_iban: null
+    applicant_name: null
+    bank_reference: D1C08A4EB4664146
+    compensation_amount: null
+    currency: EUR
+    customer_reference: 'KREF+
+
+      TFNr 01024 PayId CTSc-01 EBBMTLG:SEPA-Ueberweisungsauftrag Datei mit 0000006
+      Zahlungen'
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    debitor_identifier: null
+    deviate_applicant: null
+    deviate_recipient: null
+    end_to_end_reference: null
+    entry_date: &id017 !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    extra_details: ''
+    funds_code: R
+    guessed_entry_date: *id017
+    gvc_applicant_bin: null
+    gvc_applicant_iban: null
+    id: NTRF
+    old_SEPA_CI: null
+    old_SEPA_additional_position_reference: null
+    original_amount: null
+    posting_text: SEPA-UEBERW
+    prima_nota: 0399
+    purpose: null
+    purpose_code: null
+    recipient_name: null
+    return_debit_notes: null
+    settlement_tag: null
+    status: D
+    transaction_code: '191'
+    transaction_reference: T089413966000001
+  transactions: *id004
+- !!python/object:mt940.models.Transaction
+  data:
+    FRST_ONE_OFF_RECC: null
+    additional_position_date: null
+    additional_position_reference: null
+    additional_purpose: null
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '250000'
+      currency: EUR
+    applicant_bin: PBNKDEFF250
+    applicant_creditor_id: null
+    applicant_iban: DE40250100300325207300
+    applicant_name: Daniel Severidt 70 ZeichenBeginn Fuellzeichen xxxxxxx
+    bank_reference: 0724710290628244
+    compensation_amount: null
+    currency: EUR
+    customer_reference: NONREF
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    debitor_identifier: null
+    deviate_applicant: null
+    deviate_recipient: null
+    end_to_end_reference: null
+    entry_date: &id018 !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    extra_details: ''
+    funds_code: R
+    guessed_entry_date: *id018
+    gvc_applicant_bin: null
+    gvc_applicant_iban: null
+    id: NTRF
+    old_SEPA_CI: null
+    old_SEPA_additional_position_reference: null
+    original_amount: null
+    posting_text: GUTSCHRIFT
+    prima_nota: 0399
+    purpose: TO13 TF20010 MINT 20010 2007-08.30
+    purpose_code: null
+    recipient_name: null
+    return_debit_notes: null
+    settlement_tag: null
+    status: C
+    transaction_code: '166'
+    transaction_reference: T089413976000001
+  transactions: *id004
+- !!python/object:mt940.models.Transaction
+  data:
+    FRST_ONE_OFF_RECC: null
+    additional_position_date: null
+    additional_position_reference: null
+    additional_purpose: null
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '300000'
+      currency: EUR
+    applicant_bin: PBNKDEFF100
+    applicant_creditor_id: null
+    applicant_iban: DE40100100100000214105
+    applicant_name: Cornelia Prochownik 70 Zeichen Beginn Fuellzeichen xxx
+    bank_reference: 0724710290631813
+    compensation_amount: null
+    currency: EUR
+    customer_reference: NONREF
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    debitor_identifier: null
+    deviate_applicant: null
+    deviate_recipient: null
+    end_to_end_reference: null
+    entry_date: &id019 !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    extra_details: ''
+    funds_code: R
+    guessed_entry_date: *id019
+    gvc_applicant_bin: null
+    gvc_applicant_iban: null
+    id: NTRF
+    old_SEPA_CI: null
+    old_SEPA_additional_position_reference: null
+    original_amount: null
+    posting_text: GUTSCHRIFT
+    prima_nota: 0399
+    purpose: TO13 TF20014 MINT
+    purpose_code: null
+    recipient_name: null
+    return_debit_notes: null
+    settlement_tag: null
+    status: C
+    transaction_code: '166'
+    transaction_reference: T089413976000001
+  transactions: *id004
+- !!python/object:mt940.models.Transaction
+  data:
+    FRST_ONE_OFF_RECC: null
+    additional_position_date: null
+    additional_position_reference: null
+    additional_purpose: null
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '500000'
+      currency: EUR
+    applicant_bin: PBNKDEFF250
+    applicant_creditor_id: null
+    applicant_iban: DE39250100300172064300
+    applicant_name: Dirk Leunig 70 Zeichen Beginn Fuellzeichen xxxxxxxxxxx
+    bank_reference: 0724710290630146
+    compensation_amount: null
+    currency: EUR
+    customer_reference: NONREF
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    debitor_identifier: null
+    deviate_applicant: null
+    deviate_recipient: null
+    end_to_end_reference: null
+    entry_date: &id020 !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    extra_details: ''
+    funds_code: R
+    guessed_entry_date: *id020
+    gvc_applicant_bin: null
+    gvc_applicant_iban: null
+    id: NTRF
+    old_SEPA_CI: null
+    old_SEPA_additional_position_reference: null
+    original_amount: null
+    posting_text: GUTSCHRIFT
+    prima_nota: 0399
+    purpose: TO13 TF20011 MINT
+    purpose_code: null
+    recipient_name: null
+    return_debit_notes: null
+    settlement_tag: null
+    status: C
+    transaction_code: '166'
+    transaction_reference: T089413976000001
+  transactions: *id004
+- !!python/object:mt940.models.Transaction
+  data:
+    additional_purpose: null
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '204.88'
+      currency: EUR
+    applicant_bin: null
+    applicant_iban: null
+    applicant_name: null
+    bank_reference: null
+    currency: EUR
+    customer_reference: NONREF
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    entry_date: &id021 !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    extra_details: ''
+    funds_code: R
+    guessed_entry_date: *id021
+    id: NMSC
+    posting_text: SAMMLER
+    prima_nota: '9800'
+    purpose: 0904059001
+    recipient_name: null
+    return_debit_notes: null
+    status: C
+    transaction_code: 079
+    transaction_reference: T089413986000001
+  transactions: *id004
+- !!python/object:mt940.models.Transaction
+  data:
+    additional_purpose: null
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '-204.88'
+      currency: EUR
+    applicant_bin: null
+    applicant_iban: null
+    applicant_name: null
+    bank_reference: R724710290656678
+    currency: EUR
+    customer_reference: MSGIDCTSc03MintT
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    entry_date: &id022 !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    extra_details: ''
+    funds_code: R
+    guessed_entry_date: *id022
+    id: NRTI
+    posting_text: SEPA-UEBERW/STORNO
+    prima_nota: 0399
+    purpose: null
+    recipient_name: null
+    return_debit_notes: null
+    status: RC
+    transaction_code: '116'
+    transaction_reference: T089413986000001
+  transactions: *id004
+- !!python/object:mt940.models.Transaction
+  data:
+    FRST_ONE_OFF_RECC: null
+    additional_position_date: null
+    additional_position_reference: null
+    additional_purpose: null
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '-50990.05'
+      currency: EUR
+    applicant_bin: DRESDEFF508
+    applicant_creditor_id: null
+    applicant_iban: DE76508800500194780101
+    applicant_name: Empfaenger Florian Frech UK 01
+    bank_reference: 0724710352954937
+    compensation_amount: null
+    currency: EUR
+    customer_reference: 'KREF+
+
+      TFNR 21005 Instruction Id 00001'
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    debitor_identifier: null
+    deviate_applicant: null
+    deviate_recipient: null
+    end_to_end_reference: TFNR 21005 EndToEndId 00001
+    entry_date: &id023 !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    extra_details: ''
+    funds_code: R
+    guessed_entry_date: *id023
+    gvc_applicant_bin: null
+    gvc_applicant_iban: null
+    id: NTRF
+    old_SEPA_CI: null
+    old_SEPA_additional_position_reference: null
+    original_amount: null
+    posting_text: SEPA-UEBERW
+    prima_nota: 0399
+    purpose: Verwend CTSc-01 eBB TFNr 21005
+    purpose_code: null
+    recipient_name: null
+    return_debit_notes: null
+    settlement_tag: null
+    status: D
+    transaction_code: '116'
+    transaction_reference: T089413986000001
+  transactions: *id004
+- !!python/object:mt940.models.Transaction
+  data:
+    FRST_ONE_OFF_RECC: null
+    additional_position_date: null
+    additional_position_reference: null
+    additional_purpose: null
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '-175454.22'
+      currency: EUR
+    applicant_bin: null
+    applicant_creditor_id: null
+    applicant_iban: null
+    applicant_name: null
+    bank_reference: 8AE3169901918BD3
+    compensation_amount: null
+    currency: EUR
+    customer_reference: 'KREF+
+
+      TFNr 01009 MSGID CTSc-01 EBBMTLG:SEPA-Ueberweisungsauftrag Datei mit 0000005
+      Zahlungen'
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    debitor_identifier: null
+    deviate_applicant: null
+    deviate_recipient: null
+    end_to_end_reference: null
+    entry_date: &id024 !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    extra_details: ''
+    funds_code: R
+    guessed_entry_date: *id024
+    gvc_applicant_bin: null
+    gvc_applicant_iban: null
+    id: NTRF
+    old_SEPA_CI: null
+    old_SEPA_additional_position_reference: null
+    original_amount: null
+    posting_text: SEPA-UEBERW
+    prima_nota: 0399
+    purpose: null
+    purpose_code: null
+    recipient_name: null
+    return_debit_notes: null
+    settlement_tag: null
+    status: D
+    transaction_code: '191'
+    transaction_reference: T089413986000001
+  transactions: *id004
+- !!python/object:mt940.models.Transaction
+  data:
+    additional_purpose: null
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '-500250'
+      currency: EUR
+    applicant_bin: null
+    applicant_iban: null
+    applicant_name: null
+    bank_reference: E87048E11B394C1E
+    currency: EUR
+    customer_reference: TFNr 01006 PayId
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    entry_date: &id025 !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    extra_details: ''
+    funds_code: R
+    guessed_entry_date: *id025
+    id: NTRF
+    posting_text: SEPA-UEBERW
+    prima_nota: 0399
+    purpose: MTLG:SEPA-Ueberweisungsauftrag Datei mit 0000005 Zahlungen
+    recipient_name: null
+    return_debit_notes: null
+    status: D
+    transaction_code: '191'
+    transaction_reference: T089413986000001
+  transactions: *id004
+- !!python/object:mt940.models.Transaction
+  data:
+    FRST_ONE_OFF_RECC: null
+    additional_position_date: null
+    additional_position_reference: null
+    additional_purpose: null
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '50990.05'
+      currency: EUR
+    applicant_bin: DRESDEFF508
+    applicant_creditor_id: null
+    applicant_iban: DE06508800500194780100
+    applicant_name: Florian Frech
+    bank_reference: 0724710352954937
+    compensation_amount: null
+    currency: EUR
+    customer_reference: NONREF
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    debitor_identifier: null
+    deviate_applicant: null
+    deviate_recipient: null
+    end_to_end_reference: TFNR 21005 EndToEndId 00001
+    entry_date: &id026 !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    extra_details: ''
+    funds_code: R
+    guessed_entry_date: *id026
+    gvc_applicant_bin: null
+    gvc_applicant_iban: null
+    id: NTRF
+    old_SEPA_CI: null
+    old_SEPA_additional_position_reference: null
+    original_amount: null
+    posting_text: GUTSCHRIFT
+    prima_nota: 0399
+    purpose: Verwend CTSc-01 eBB TFNr 21005
+    purpose_code: null
+    recipient_name: null
+    return_debit_notes: null
+    settlement_tag: null
+    status: C
+    transaction_code: '166'
+    transaction_reference: T089413996000001
+  transactions: *id004
+- !!python/object:mt940.models.Transaction
+  data:
+    FRST_ONE_OFF_RECC: null
+    additional_position_date: null
+    additional_position_reference: null
+    additional_purpose: null
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '19990.05'
+      currency: EUR
+    applicant_bin: DRESDEFF508
+    applicant_creditor_id: null
+    applicant_iban: DE95508800500194784900
+    applicant_name: JOSEF        JAEGER
+    bank_reference: 0724710333377198
+    compensation_amount: null
+    currency: EUR
+    customer_reference: NONREF
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    debitor_identifier: null
+    deviate_applicant: null
+    deviate_recipient: null
+    end_to_end_reference: EndToEndId TFNR 22 001 00001
+    entry_date: &id027 !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    extra_details: ''
+    funds_code: R
+    guessed_entry_date: *id027
+    gvc_applicant_bin: null
+    gvc_applicant_iban: null
+    id: NTRF
+    old_SEPA_CI: null
+    old_SEPA_additional_position_reference: null
+    original_amount: null
+    posting_text: GUTSCHRIFT
+    prima_nota: 0399
+    purpose: 'Verwend CTSc-01 PPP TFNr 22 001MTLG:SEPA-Ueberweisungseingang Auftraggeber:
+      JOSEF'
+    purpose_code: null
+    recipient_name: null
+    return_debit_notes: null
+    settlement_tag: null
+    status: C
+    transaction_code: '166'
+    transaction_reference: T089414006000001
+  transactions: *id004
+- !!python/object:mt940.models.Transaction
+  data:
+    FRST_ONE_OFF_RECC: null
+    additional_position_date: null
+    additional_position_reference: null
+    additional_purpose: null
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '-57.34'
+      currency: EUR
+    applicant_bin: SOGEFRPPXXX
+    applicant_creditor_id: null
+    applicant_iban: FR1420041010050500013M02606
+    applicant_name: Empfaenger 1 mit 70 Zeichen Empfaenger 1 mit 70 Zeiche
+    bank_reference: 0724710352996674
+    compensation_amount: null
+    currency: EUR
+    customer_reference: 'KREF+
+
+      TFNR 01011 Instruction Id  00001'
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    debitor_identifier: null
+    deviate_applicant: null
+    deviate_recipient: null
+    end_to_end_reference: NONREF
+    entry_date: &id028 !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    extra_details: ''
+    funds_code: R
+    guessed_entry_date: *id028
+    gvc_applicant_bin: null
+    gvc_applicant_iban: null
+    id: NTRF
+    old_SEPA_CI: null
+    old_SEPA_additional_position_reference: null
+    original_amount: null
+    posting_text: SEPA-UEBERW
+    prima_nota: 0399
+    purpose: Unstrukturierter Verwendungszweck mit140 Stellen fu/r SEPA COR Buchungsschema
+      /A-CT-DTE-S01 undA-CT-NUD-/S01 CTSc-01 EBB TFNr 01011/ 0001
+    purpose_code: null
+    recipient_name: null
+    return_debit_notes: null
+    settlement_tag: null
+    status: D
+    transaction_code: '116'
+    transaction_reference: T089414006000001
+  transactions: *id004
+- !!python/object:mt940.models.Transaction
+  data:
+    FRST_ONE_OFF_RECC: null
+    additional_position_date: null
+    additional_position_reference: null
+    additional_purpose: null
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '-5002.17'
+      currency: EUR
+    applicant_bin: SOGEFRPPXXX
+    applicant_creditor_id: null
+    applicant_iban: FR1420041010050500013M02606
+    applicant_name: Empfaenger 6mit 70 Zeichen Empfaenger 6 mit 70 Zeiche
+    bank_reference: 0724710353006393
+    compensation_amount: null
+    currency: EUR
+    customer_reference: TFNr 01011 MSGID
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    debitor_identifier: null
+    deviate_applicant: null
+    deviate_recipient: null
+    end_to_end_reference: NONREF
+    entry_date: &id029 !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    extra_details: ''
+    funds_code: R
+    guessed_entry_date: *id029
+    gvc_applicant_bin: null
+    gvc_applicant_iban: null
+    id: NTRF
+    old_SEPA_CI: null
+    old_SEPA_additional_position_reference: null
+    original_amount: null
+    posting_text: SEPA-UEBERW
+    prima_nota: 0399
+    purpose: Unstrukturierter Verwendungszweck mit 140 Stellen fu/r SEPA COR Buchungsschema
+      /A-CT-DTE-S01 und A-CT-NUD-/S01 CTSc-01 EBB TFNr 01011/ 0006
+    purpose_code: null
+    recipient_name: null
+    return_debit_notes: null
+    settlement_tag: null
+    status: D
+    transaction_code: '116'
+    transaction_reference: T089414006000001
+  transactions: *id004
+- !!python/object:mt940.models.Transaction
+  data:
+    FRST_ONE_OFF_RECC: null
+    additional_position_date: null
+    additional_position_reference: null
+    additional_purpose: null
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '-5002.17'
+      currency: EUR
+    applicant_bin: SOGEFRPPXXX
+    applicant_creditor_id: null
+    applicant_iban: FR1420041010050500013M02606
+    applicant_name: Empfaenger 2 mit 70 Zeichen Empfaenger 2 mit 70 Zeiche
+    bank_reference: 0724710352998444
+    compensation_amount: null
+    currency: EUR
+    customer_reference: 'KREF+
+
+      TFNR 01011 Instruction Id  00002'
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    debitor_identifier: null
+    deviate_applicant: null
+    deviate_recipient: null
+    end_to_end_reference: NONREF
+    entry_date: &id030 !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    extra_details: ''
+    funds_code: R
+    guessed_entry_date: *id030
+    gvc_applicant_bin: null
+    gvc_applicant_iban: null
+    id: NTRF
+    old_SEPA_CI: null
+    old_SEPA_additional_position_reference: null
+    original_amount: null
+    posting_text: SEPA-UEBERW
+    prima_nota: 0399
+    purpose: Unstrukturierter Verwendungszweck mit140 Stellen fu/r SEPA COR Buchungsschema
+      /A-CT-DTE-S01 undA-CT-NUD-/S01 CTSc-01 EBB TFNr 01011/ 0002
+    purpose_code: null
+    recipient_name: null
+    return_debit_notes: null
+    settlement_tag: null
+    status: D
+    transaction_code: '116'
+    transaction_reference: T089414006000001
+  transactions: *id004
+- !!python/object:mt940.models.Transaction
+  data:
+    FRST_ONE_OFF_RECC: null
+    additional_position_date: null
+    additional_position_reference: null
+    additional_purpose: null
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '-5002.17'
+      currency: EUR
+    applicant_bin: SOGEFRPPXXX
+    applicant_creditor_id: null
+    applicant_iban: FR1420041010050500013M02606
+    applicant_name: Empfaenger 4 mit 70 Zeichen Empfaenger 4 mit 70 Zeiche
+    bank_reference: 0724710353002818
+    compensation_amount: null
+    currency: EUR
+    customer_reference: 'KREF+
+
+      TFNR 01011 Instruction Id  00004'
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    debitor_identifier: null
+    deviate_applicant: null
+    deviate_recipient: null
+    end_to_end_reference: NONREF
+    entry_date: &id031 !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    extra_details: ''
+    funds_code: R
+    guessed_entry_date: *id031
+    gvc_applicant_bin: null
+    gvc_applicant_iban: null
+    id: NTRF
+    old_SEPA_CI: null
+    old_SEPA_additional_position_reference: null
+    original_amount: null
+    posting_text: SEPA-UEBERW
+    prima_nota: 0399
+    purpose: Unstrukturierter Verwendungszweck mit140 Stellen fu/r SEPA COR Buchungsschema
+      /A-CT-DTE-S01 undA-CT-NUD-/S01 CTSc-01 EBB TFNr 01011/ 0004
+    purpose_code: null
+    recipient_name: null
+    return_debit_notes: null
+    settlement_tag: null
+    status: D
+    transaction_code: '116'
+    transaction_reference: T089414006000002
+  transactions: *id004
+- !!python/object:mt940.models.Transaction
+  data:
+    FRST_ONE_OFF_RECC: null
+    additional_position_date: null
+    additional_position_reference: null
+    additional_purpose: null
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '-5002.17'
+      currency: EUR
+    applicant_bin: SOGEFRPPXXX
+    applicant_creditor_id: null
+    applicant_iban: FR1420041010050500013M02606
+    applicant_name: Empfaenger 3 mit 70 Zeichen Empfaenger 3 mit 70 Zeiche
+    bank_reference: 0724710353000284
+    compensation_amount: null
+    currency: EUR
+    customer_reference: 'KREF+
+
+      TFNR 01011 Instruction Id  00003'
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    debitor_identifier: null
+    deviate_applicant: null
+    deviate_recipient: null
+    end_to_end_reference: NONREF
+    entry_date: &id032 !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    extra_details: ''
+    funds_code: R
+    guessed_entry_date: *id032
+    gvc_applicant_bin: null
+    gvc_applicant_iban: null
+    id: NTRF
+    old_SEPA_CI: null
+    old_SEPA_additional_position_reference: null
+    original_amount: null
+    posting_text: SEPA-UEBERW
+    prima_nota: 0399
+    purpose: Unstrukturierter Verwendungszweck mit140 Stellen fu/r SEPA COR Buchungsschema
+      /A-CT-DTE-S01 undA-CT-NUD-/S01 CTSc-01 EBB TFNr 01011/ 0003
+    purpose_code: null
+    recipient_name: null
+    return_debit_notes: null
+    settlement_tag: null
+    status: D
+    transaction_code: '116'
+    transaction_reference: T089414006000002
+  transactions: *id004
+- !!python/object:mt940.models.Transaction
+  data:
+    FRST_ONE_OFF_RECC: null
+    additional_position_date: null
+    additional_position_reference: null
+    additional_purpose: null
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '-5002.17'
+      currency: EUR
+    applicant_bin: SOGEFRPPXXX
+    applicant_creditor_id: null
+    applicant_iban: FR1420041010050500013M02606
+    applicant_name: Empfaenger 5 mit 70 Zeichen Empfaenger 5 mit 70 Zeiche
+    bank_reference: 0724710353004695
+    compensation_amount: null
+    currency: EUR
+    customer_reference: 'KREF+
+
+      TFNR 01011 Instruction Id  00005'
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    debitor_identifier: null
+    deviate_applicant: null
+    deviate_recipient: null
+    end_to_end_reference: NONREF
+    entry_date: &id033 !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    extra_details: ''
+    funds_code: R
+    guessed_entry_date: *id033
+    gvc_applicant_bin: null
+    gvc_applicant_iban: null
+    id: NTRF
+    old_SEPA_CI: null
+    old_SEPA_additional_position_reference: null
+    original_amount: null
+    posting_text: SEPA-UEBERW
+    prima_nota: 0399
+    purpose: Unstrukturierter Verwendungszweck mit140 Stellen fu/r SEPA COR Buchungsschema
+      /A-CT-DTE-S01 undA-CT-NUD-/S01 CTSc-01 EBB TFNr 01011/ 0005
+    purpose_code: null
+    recipient_name: null
+    return_debit_notes: null
+    settlement_tag: null
+    status: D
+    transaction_code: '116'
+    transaction_reference: T089414006000002
+  transactions: *id004
+- !!python/object:mt940.models.Transaction
+  data:
+    FRST_ONE_OFF_RECC: null
+    additional_position_date: null
+    additional_position_reference: null
+    additional_purpose: beachten
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '-55344.11'
+      currency: EUR
+    applicant_bin: SOGEFRPPXXX
+    applicant_creditor_id: null
+    applicant_iban: FR1420041010050500013M02606
+    applicant_name: Empfaenger 7 mit 70 Zeichen Empfaenger 7 mit 70 Zeiche
+    bank_reference: 0724710353008994
+    compensation_amount: null
+    currency: EUR
+    customer_reference: 'KREF+
+
+      TFNR 01011 Instruction Id  00007'
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    debitor_identifier: null
+    deviate_applicant: null
+    deviate_recipient: null
+    end_to_end_reference: NONREF
+    entry_date: &id034 !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    extra_details: ''
+    funds_code: R
+    guessed_entry_date: *id034
+    gvc_applicant_bin: null
+    gvc_applicant_iban: null
+    id: NTRF
+    old_SEPA_CI: null
+    old_SEPA_additional_position_reference: null
+    original_amount: null
+    posting_text: SEPA-UEBERW
+    prima_nota: 0399
+    purpose: 'Unstrukturierter Verwendungszweck mit140 Stellen fu/r SEPA COR Buchungsschema
+      /A-CT-DTE-S01 undA-CT-NUD-/S01 CTSc-01 EBB TFNr 01011/ 0007MTLG:Ggf.Meldevorschriften '
+    purpose_code: null
+    recipient_name: null
+    return_debit_notes: null
+    settlement_tag: null
+    status: D
+    transaction_code: '116'
+    transaction_reference: T089414006000002
+  transactions: *id004
+- !!python/object:mt940.models.Transaction
+  data:
+    FRST_ONE_OFF_RECC: null
+    additional_position_date: null
+    additional_position_reference: null
+    additional_purpose: null
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '50'
+      currency: EUR
+    applicant_bin: null
+    applicant_creditor_id: null
+    applicant_iban: null
+    applicant_name: null
+    bank_reference: 0724710324649377
+    compensation_amount: null
+    currency: EUR
+    customer_reference: TFNr 40016 MSGID
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    debitor_identifier: null
+    deviate_applicant: null
+    deviate_recipient: null
+    end_to_end_reference: TFNR 40016 00001MTLG:Grund nicht spezifiziert Reject aus
+      SEPA-Ueberweisungsauftrag
+    entry_date: &id035 !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    extra_details: ''
+    funds_code: R
+    guessed_entry_date: *id035
+    gvc_applicant_bin: null
+    gvc_applicant_iban: null
+    id: NTRF
+    old_SEPA_CI: null
+    old_SEPA_additional_position_reference: null
+    original_amount: null
+    posting_text: RETOURE
+    prima_nota: 0399
+    purpose: null
+    purpose_code: null
+    recipient_name: null
+    return_debit_notes: '914'
+    settlement_tag: null
+    status: C
+    transaction_code: '159'
+    transaction_reference: T089414016000001
+  transactions: *id004
+- !!python/object:mt940.models.Transaction
+  data:
+    FRST_ONE_OFF_RECC: null
+    additional_position_date: null
+    additional_position_reference: null
+    additional_purpose: null
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '50.05'
+      currency: EUR
+    applicant_bin: null
+    applicant_creditor_id: null
+    applicant_iban: null
+    applicant_name: null
+    bank_reference: 0724710345347489
+    compensation_amount: null
+    currency: EUR
+    customer_reference: MCCT070927000002
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    debitor_identifier: null
+    deviate_applicant: null
+    deviate_recipient: null
+    end_to_end_reference: TFNR 40017 00001MTLG:Grund nicht spezifiziert Reject aus
+      SEPA-Ueberweisungsauftrag
+    entry_date: &id036 !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    extra_details: ''
+    funds_code: R
+    guessed_entry_date: *id036
+    gvc_applicant_bin: null
+    gvc_applicant_iban: null
+    id: NTRF
+    old_SEPA_CI: null
+    old_SEPA_additional_position_reference: null
+    original_amount: null
+    posting_text: RETOURE
+    prima_nota: 0399
+    purpose: null
+    purpose_code: null
+    recipient_name: null
+    return_debit_notes: '914'
+    settlement_tag: null
+    status: C
+    transaction_code: '159'
+    transaction_reference: T089414016000001
+  transactions: *id004
+- !!python/object:mt940.models.Transaction
+  data:
+    FRST_ONE_OFF_RECC: null
+    additional_position_date: null
+    additional_position_reference: null
+    additional_purpose: null
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '50.05'
+      currency: EUR
+    applicant_bin: null
+    applicant_creditor_id: null
+    applicant_iban: null
+    applicant_name: null
+    bank_reference: '0724710351065632'
+    compensation_amount: null
+    currency: EUR
+    customer_reference: MCCT070927000004
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    debitor_identifier: null
+    deviate_applicant: null
+    deviate_recipient: null
+    end_to_end_reference: TFNR 40018 00001MTLG:Grund nicht spezifiziert Reject aus
+      SEPA-Ueberweisungsauftrag
+    entry_date: &id037 !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    extra_details: ''
+    funds_code: R
+    guessed_entry_date: *id037
+    gvc_applicant_bin: null
+    gvc_applicant_iban: null
+    id: NTRF
+    old_SEPA_CI: null
+    old_SEPA_additional_position_reference: null
+    original_amount: null
+    posting_text: RETOURE
+    prima_nota: 0399
+    purpose: null
+    purpose_code: null
+    recipient_name: null
+    return_debit_notes: '914'
+    settlement_tag: null
+    status: C
+    transaction_code: '159'
+    transaction_reference: T089414016000001
+  transactions: *id004
+- !!python/object:mt940.models.Transaction
+  data:
+    FRST_ONE_OFF_RECC: null
+    additional_position_date: null
+    additional_position_reference: null
+    additional_purpose: null
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '46500.07'
+      currency: EUR
+    applicant_bin: null
+    applicant_creditor_id: null
+    applicant_iban: null
+    applicant_name: null
+    bank_reference: '0724710333347237'
+    compensation_amount: null
+    currency: EUR
+    customer_reference: 'KREF+
+
+      EndToEndId TFNR 06 004 00002MTLG:Grund nicht spezifiziert Reject aus SEPA-Ueberweisungsauftrag'
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    debitor_identifier: null
+    deviate_applicant: null
+    deviate_recipient: null
+    end_to_end_reference: EndToEndId TFNR 06 004 00002
+    entry_date: &id038 !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    extra_details: ''
+    funds_code: R
+    guessed_entry_date: *id038
+    gvc_applicant_bin: null
+    gvc_applicant_iban: null
+    id: NTRF
+    old_SEPA_CI: null
+    old_SEPA_additional_position_reference: null
+    original_amount: null
+    posting_text: RETOURE
+    prima_nota: 0399
+    purpose: null
+    purpose_code: null
+    recipient_name: null
+    return_debit_notes: '914'
+    settlement_tag: null
+    status: C
+    transaction_code: '159'
+    transaction_reference: T089414016000001
+  transactions: *id004
+- !!python/object:mt940.models.Transaction
+  data:
+    FRST_ONE_OFF_RECC: null
+    additional_position_date: null
+    additional_position_reference: null
+    additional_purpose: null
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '154551.93'
+      currency: EUR
+    applicant_bin: null
+    applicant_creditor_id: null
+    applicant_iban: null
+    applicant_name: null
+    bank_reference: '0724710333347241'
+    compensation_amount: null
+    currency: EUR
+    customer_reference: 'KREF+
+
+      EndToEndId TFNR 06 004 00004MTLG:Grund nicht spezifiziert Reject aus SEPA-Ueberweisungsauftrag'
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    debitor_identifier: null
+    deviate_applicant: null
+    deviate_recipient: null
+    end_to_end_reference: EndToEndId TFNR 06 004 00004
+    entry_date: &id039 !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    extra_details: ''
+    funds_code: R
+    guessed_entry_date: *id039
+    gvc_applicant_bin: null
+    gvc_applicant_iban: null
+    id: NTRF
+    old_SEPA_CI: null
+    old_SEPA_additional_position_reference: null
+    original_amount: null
+    posting_text: RETOURE
+    prima_nota: 0399
+    purpose: null
+    purpose_code: null
+    recipient_name: null
+    return_debit_notes: '914'
+    settlement_tag: null
+    status: C
+    transaction_code: '159'
+    transaction_reference: T089414016000001
+  transactions: *id004
+- !!python/object:mt940.models.Transaction
+  data:
+    FRST_ONE_OFF_RECC: null
+    additional_position_date: null
+    additional_position_reference: null
+    additional_purpose: null
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '-2550'
+      currency: EUR
+    applicant_bin: null
+    applicant_creditor_id: null
+    applicant_iban: null
+    applicant_name: null
+    bank_reference: 31408CF87AD5901E
+    compensation_amount: null
+    currency: EUR
+    customer_reference: 'KREF+
+
+      TFNr 40016 PayId CTSc-02 PPPMTLG:SEPA-Ueberweisungsauftrag Datei mit 0000002
+      Zahlungen'
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    debitor_identifier: null
+    deviate_applicant: null
+    deviate_recipient: null
+    end_to_end_reference: null
+    entry_date: &id040 !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    extra_details: ''
+    funds_code: R
+    guessed_entry_date: *id040
+    gvc_applicant_bin: null
+    gvc_applicant_iban: null
+    id: NTRF
+    old_SEPA_CI: null
+    old_SEPA_additional_position_reference: null
+    original_amount: null
+    posting_text: SEPA-UEBERW
+    prima_nota: 0399
+    purpose: null
+    purpose_code: null
+    recipient_name: null
+    return_debit_notes: null
+    settlement_tag: null
+    status: D
+    transaction_code: '191'
+    transaction_reference: T089414016000001
+  transactions: *id004
+- !!python/object:mt940.models.Transaction
+  data:
+    additional_purpose: null
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '-2550.12'
+      currency: EUR
+    applicant_bin: null
+    applicant_iban: null
+    applicant_name: null
+    bank_reference: 4F112D73FF96F4FB
+    currency: EUR
+    customer_reference: MCCT07090401
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    entry_date: &id041 !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    extra_details: ''
+    funds_code: R
+    guessed_entry_date: *id041
+    id: NTRF
+    posting_text: SEPA-UEBERW
+    prima_nota: 0399
+    purpose: MTLG:SEPA-Ueberweisungsauftrag Datei mit 0000002 Zahlungen
+    recipient_name: null
+    return_debit_notes: null
+    status: D
+    transaction_code: '191'
+    transaction_reference: T089414016000001
+  transactions: *id004
+- !!python/object:mt940.models.Transaction
+  data:
+    additional_purpose: null
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '-2550.12'
+      currency: EUR
+    applicant_bin: null
+    applicant_iban: null
+    applicant_name: null
+    bank_reference: EC4BA14CEA34BFF3
+    currency: EUR
+    customer_reference: MCCT07090402
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    entry_date: &id042 !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    extra_details: ''
+    funds_code: R
+    guessed_entry_date: *id042
+    id: NTRF
+    posting_text: SEPA-UEBERW
+    prima_nota: 0399
+    purpose: MTLG:SEPA-Ueberweisungsauftrag Datei mit 0000002 Zahlungen
+    recipient_name: null
+    return_debit_notes: null
+    status: D
+    transaction_code: '191'
+    transaction_reference: T089414016000001
+  transactions: *id004
+- !!python/object:mt940.models.Transaction
+  data:
+    additional_purpose: null
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '-65500.15'
+      currency: EUR
+    applicant_bin: null
+    applicant_iban: null
+    applicant_name: null
+    bank_reference: 92D891C454BC30B5
+    currency: EUR
+    customer_reference: NONREF
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    entry_date: &id043 !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    extra_details: ''
+    funds_code: R
+    guessed_entry_date: *id043
+    id: NTRF
+    posting_text: ONLINE-UEBW.
+    prima_nota: 0399
+    purpose: 'MTLG:SBI-SEPA-SAMMELUEB.Anz:4 Referenz: 1930467114 Erfassung mit 004
+      Zahlungen'
+    recipient_name: null
+    return_debit_notes: null
+    status: D
+    transaction_code: '191'
+    transaction_reference: T089414016000002
+  transactions: *id004
+- !!python/object:mt940.models.Transaction
+  data:
+    additional_purpose: null
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '-402104'
+      currency: EUR
+    applicant_bin: null
+    applicant_iban: null
+    applicant_name: null
+    bank_reference: 57B4197CC644DE8F
+    currency: EUR
+    customer_reference: NONREF
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    entry_date: &id044 !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    extra_details: ''
+    funds_code: R
+    guessed_entry_date: *id044
+    id: NTRF
+    posting_text: ONLINE-UEBW.
+    prima_nota: 0399
+    purpose: 'MTLG:SBI-SEPA-SAMMELUEB.Anz:4 Referenz: 1930467115 Erfassung mit 004
+      Zahlungen'
+    recipient_name: null
+    return_debit_notes: null
+    status: D
+    transaction_code: '191'
+    transaction_reference: T089414016000002
+  transactions: *id004
+- !!python/object:mt940.models.Transaction
+  data:
+    FRST_ONE_OFF_RECC: null
+    additional_position_date: null
+    additional_position_reference: null
+    additional_purpose: null
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '-476921.44'
+      currency: EUR
+    applicant_bin: null
+    applicant_creditor_id: null
+    applicant_iban: null
+    applicant_name: null
+    bank_reference: 06F8672B28B7A92F
+    compensation_amount: null
+    currency: EUR
+    customer_reference: 'KREF+
+
+      TFNr 41003 PayId CTSc-01 EBBMTLG:SEPA-Ueberweisungsauftrag Datei mit 0000004
+      Zahlungen'
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    debitor_identifier: null
+    deviate_applicant: null
+    deviate_recipient: null
+    end_to_end_reference: null
+    entry_date: &id045 !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    extra_details: ''
+    funds_code: R
+    guessed_entry_date: *id045
+    gvc_applicant_bin: null
+    gvc_applicant_iban: null
+    id: NTRF
+    old_SEPA_CI: null
+    old_SEPA_additional_position_reference: null
+    original_amount: null
+    posting_text: SEPA-UEBERW
+    prima_nota: 0399
+    purpose: null
+    purpose_code: null
+    recipient_name: null
+    return_debit_notes: null
+    settlement_tag: null
+    status: D
+    transaction_code: '191'
+    transaction_reference: T089414016000002
+  transactions: *id004
+- !!python/object:mt940.models.Transaction
+  data:
+    FRST_ONE_OFF_RECC: null
+    additional_position_date: null
+    additional_position_reference: null
+    additional_purpose: null
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '335.33'
+      currency: EUR
+    applicant_bin: null
+    applicant_creditor_id: null
+    applicant_iban: null
+    applicant_name: null
+    bank_reference: 0724710351059240
+    compensation_amount: null
+    currency: EUR
+    customer_reference: TFNr 44005 MSGID
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    debitor_identifier: null
+    deviate_applicant: null
+    deviate_recipient: null
+    end_to_end_reference: TFNR 44005 00001MTLG:Grund nicht spezifiziert Reject aus
+      SEPA-Ueberweisungsauftrag
+    entry_date: &id046 !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    extra_details: ''
+    funds_code: R
+    guessed_entry_date: *id046
+    gvc_applicant_bin: null
+    gvc_applicant_iban: null
+    id: NTRF
+    old_SEPA_CI: null
+    old_SEPA_additional_position_reference: null
+    original_amount: null
+    posting_text: RETOURE
+    prima_nota: 0399
+    purpose: null
+    purpose_code: null
+    recipient_name: null
+    return_debit_notes: '914'
+    settlement_tag: null
+    status: C
+    transaction_code: '159'
+    transaction_reference: T089414026000001
+  transactions: *id004
+- !!python/object:mt940.models.Transaction
+  data:
+    FRST_ONE_OFF_RECC: null
+    additional_position_date: null
+    additional_position_reference: null
+    additional_purpose: null
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '915311.55'
+      currency: EUR
+    applicant_bin: null
+    applicant_creditor_id: null
+    applicant_iban: null
+    applicant_name: null
+    bank_reference: R724710351059243
+    compensation_amount: null
+    currency: EUR
+    customer_reference: TFNr 44005 MSGID
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    debitor_identifier: null
+    deviate_applicant: null
+    deviate_recipient: null
+    end_to_end_reference: TFNR 44005 00002MTLG:Konto gesperrt Rueckueberweisung aus
+      SEPA-Ueberweisungsauftrag
+    entry_date: &id047 !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    extra_details: ''
+    funds_code: R
+    guessed_entry_date: *id047
+    gvc_applicant_bin: null
+    gvc_applicant_iban: null
+    id: NTRF
+    old_SEPA_CI: null
+    old_SEPA_additional_position_reference: null
+    original_amount: null
+    posting_text: RETOURE
+    prima_nota: 0399
+    purpose: null
+    purpose_code: null
+    recipient_name: null
+    return_debit_notes: '903'
+    settlement_tag: null
+    status: C
+    transaction_code: '159'
+    transaction_reference: T089414026000001
+  transactions: *id004
+- !!python/object:mt940.models.Transaction
+  data:
+    FRST_ONE_OFF_RECC: null
+    additional_position_date: null
+    additional_position_reference: null
+    additional_purpose: null
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '-157.34'
+      currency: EUR
+    applicant_bin: SOGEFRPPXXX
+    applicant_creditor_id: null
+    applicant_iban: FR1420041010050500013M02606
+    applicant_name: Empfaenger 1 mit 70 Zeichen Empfaenger 1 mit 70 Zeiche
+    bank_reference: 0724710360914647
+    compensation_amount: null
+    currency: EUR
+    customer_reference: 'KREF+
+
+      TFNR 01041  Instruction Id 00001'
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    debitor_identifier: null
+    deviate_applicant: null
+    deviate_recipient: null
+    end_to_end_reference: TFNR 01041 00001
+    entry_date: &id048 !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    extra_details: ''
+    funds_code: R
+    guessed_entry_date: *id048
+    gvc_applicant_bin: null
+    gvc_applicant_iban: null
+    id: NTRF
+    old_SEPA_CI: null
+    old_SEPA_additional_position_reference: null
+    original_amount: null
+    posting_text: SEPA-UEBERW
+    prima_nota: 0399
+    purpose: Strukturierter Verwendungszweck EBB 01041 001 DE
+    purpose_code: null
+    recipient_name: null
+    return_debit_notes: null
+    settlement_tag: null
+    status: D
+    transaction_code: '116'
+    transaction_reference: T089414026000001
+  transactions: *id004
+- !!python/object:mt940.models.Transaction
+  data:
+    FRST_ONE_OFF_RECC: null
+    additional_position_date: null
+    additional_position_reference: null
+    additional_purpose: null
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '-6002.17'
+      currency: EUR
+    applicant_bin: SOGEFRPPXXX
+    applicant_creditor_id: null
+    applicant_iban: FR1420041010050500013M02606
+    applicant_name: Empfaenger 2 mit 70 Zeichen Empfaenger 2 mit 70 Zeiche
+    bank_reference: 0724710360912501
+    compensation_amount: null
+    currency: EUR
+    customer_reference: 'KREF+
+
+      TFNR 01041  Instruction Id 00002'
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    debitor_identifier: null
+    deviate_applicant: null
+    deviate_recipient: null
+    end_to_end_reference: TFNR 01041 00002
+    entry_date: &id049 !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    extra_details: ''
+    funds_code: R
+    guessed_entry_date: *id049
+    gvc_applicant_bin: null
+    gvc_applicant_iban: null
+    id: NTRF
+    old_SEPA_CI: null
+    old_SEPA_additional_position_reference: null
+    original_amount: null
+    posting_text: SEPA-UEBERW
+    prima_nota: 0399
+    purpose: Strukturierter Verwendungszweck EBB 01041 002 DE
+    purpose_code: null
+    recipient_name: null
+    return_debit_notes: null
+    settlement_tag: null
+    status: D
+    transaction_code: '116'
+    transaction_reference: T089414026000001
+  transactions: *id004
+- !!python/object:mt940.models.Transaction
+  data:
+    FRST_ONE_OFF_RECC: null
+    additional_position_date: null
+    additional_position_reference: null
+    additional_purpose: null
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '-6002.17'
+      currency: EUR
+    applicant_bin: SOGEFRPPXXX
+    applicant_creditor_id: null
+    applicant_iban: FR1420041010050500013M02606
+    applicant_name: Empfaenger 5 mit 70 Zeichen Empfaenger 5 mit 70 Zeiche
+    bank_reference: 0724710360923556
+    compensation_amount: null
+    currency: EUR
+    customer_reference: 'KREF+
+
+      TFNR 01041  Instruction Id 00005'
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    debitor_identifier: null
+    deviate_applicant: null
+    deviate_recipient: null
+    end_to_end_reference: TFNR 01041 00005
+    entry_date: &id050 !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    extra_details: ''
+    funds_code: R
+    guessed_entry_date: *id050
+    gvc_applicant_bin: null
+    gvc_applicant_iban: null
+    id: NTRF
+    old_SEPA_CI: null
+    old_SEPA_additional_position_reference: null
+    original_amount: null
+    posting_text: SEPA-UEBERW
+    prima_nota: 0399
+    purpose: Strukturierter Verwendungszweck EBB 01041 005 DE
+    purpose_code: null
+    recipient_name: null
+    return_debit_notes: null
+    settlement_tag: null
+    status: D
+    transaction_code: '116'
+    transaction_reference: T089414026000001
+  transactions: *id004
+- !!python/object:mt940.models.Transaction
+  data:
+    FRST_ONE_OFF_RECC: null
+    additional_position_date: null
+    additional_position_reference: null
+    additional_purpose: null
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '-6002.17'
+      currency: EUR
+    applicant_bin: SOGEFRPPXXX
+    applicant_creditor_id: null
+    applicant_iban: FR1420041010050500013M02606
+    applicant_name: Empfaenger 6 mit 70 Zeichen Empfaenger 6 mit 70 Zeiche
+    bank_reference: 0724710360910575
+    compensation_amount: null
+    currency: EUR
+    customer_reference: 'KREF+
+
+      TFNR 01041  Instruction Id 00006'
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    debitor_identifier: null
+    deviate_applicant: null
+    deviate_recipient: null
+    end_to_end_reference: TFNR 01041 00006
+    entry_date: &id051 !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    extra_details: ''
+    funds_code: R
+    guessed_entry_date: *id051
+    gvc_applicant_bin: null
+    gvc_applicant_iban: null
+    id: NTRF
+    old_SEPA_CI: null
+    old_SEPA_additional_position_reference: null
+    original_amount: null
+    posting_text: SEPA-UEBERW
+    prima_nota: 0399
+    purpose: Strukturierter Verwendungszweck EBB 01041 006 DE
+    purpose_code: null
+    recipient_name: null
+    return_debit_notes: null
+    settlement_tag: null
+    status: D
+    transaction_code: '116'
+    transaction_reference: T089414026000001
+  transactions: *id004
+- !!python/object:mt940.models.Transaction
+  data:
+    FRST_ONE_OFF_RECC: null
+    additional_position_date: null
+    additional_position_reference: null
+    additional_purpose: null
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '-6002.17'
+      currency: EUR
+    applicant_bin: SOGEFRPPXXX
+    applicant_creditor_id: null
+    applicant_iban: FR1420041010050500013M02606
+    applicant_name: Empfaenger 4 mit 70 Zeichen Empfaenger 4 mit 70 Zeiche
+    bank_reference: 0724710360918027
+    compensation_amount: null
+    currency: EUR
+    customer_reference: 'KREF+
+
+      TFNR 01041  Instruction Id 00004'
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    debitor_identifier: null
+    deviate_applicant: null
+    deviate_recipient: null
+    end_to_end_reference: TFNR 01041 00004
+    entry_date: &id052 !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    extra_details: ''
+    funds_code: R
+    guessed_entry_date: *id052
+    gvc_applicant_bin: null
+    gvc_applicant_iban: null
+    id: NTRF
+    old_SEPA_CI: null
+    old_SEPA_additional_position_reference: null
+    original_amount: null
+    posting_text: SEPA-UEBERW
+    prima_nota: 0399
+    purpose: Strukturierter Verwendungszweck EBB 01041 004 DE
+    purpose_code: null
+    recipient_name: null
+    return_debit_notes: null
+    settlement_tag: null
+    status: D
+    transaction_code: '116'
+    transaction_reference: T089414026000002
+  transactions: *id004
+- !!python/object:mt940.models.Transaction
+  data:
+    FRST_ONE_OFF_RECC: null
+    additional_position_date: null
+    additional_position_reference: null
+    additional_purpose: null
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '-6002.17'
+      currency: EUR
+    applicant_bin: SOGEFRPPXXX
+    applicant_creditor_id: null
+    applicant_iban: FR1420041010050500013M02606
+    applicant_name: Empfaenger 3 mit 70 Zeichen Empfaenger 3 mit 70 Zeiche
+    bank_reference: 0724710360916341
+    compensation_amount: null
+    currency: EUR
+    customer_reference: 'KREF+
+
+      TFNR 01041  Instruction Id 00003'
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    debitor_identifier: null
+    deviate_applicant: null
+    deviate_recipient: null
+    end_to_end_reference: TFNR 01041 00003
+    entry_date: &id053 !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    extra_details: ''
+    funds_code: R
+    guessed_entry_date: *id053
+    gvc_applicant_bin: null
+    gvc_applicant_iban: null
+    id: NTRF
+    old_SEPA_CI: null
+    old_SEPA_additional_position_reference: null
+    original_amount: null
+    posting_text: SEPA-UEBERW
+    prima_nota: 0399
+    purpose: Strukturierter Verwendungszweck EBB 01041 003 DE
+    purpose_code: null
+    recipient_name: null
+    return_debit_notes: null
+    settlement_tag: null
+    status: D
+    transaction_code: '116'
+    transaction_reference: T089414026000002
+  transactions: *id004
+- !!python/object:mt940.models.Transaction
+  data:
+    FRST_ONE_OFF_RECC: null
+    additional_position_date: null
+    additional_position_reference: null
+    additional_purpose: null
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '-155344.11'
+      currency: EUR
+    applicant_bin: SOGEFRPPXXX
+    applicant_creditor_id: null
+    applicant_iban: FR1420041010050500013M02606
+    applicant_name: Empfaenger 7 mit 70 Zeichen Empfaenger 7 mit 70 Zeiche
+    bank_reference: 0724710360908674
+    compensation_amount: null
+    currency: EUR
+    customer_reference: 'KREF+
+
+      TFNR 01041  Instruction Id 00007'
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    debitor_identifier: null
+    deviate_applicant: null
+    deviate_recipient: null
+    end_to_end_reference: TFNR 01041 00007
+    entry_date: &id054 !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    extra_details: ''
+    funds_code: R
+    guessed_entry_date: *id054
+    gvc_applicant_bin: null
+    gvc_applicant_iban: null
+    id: NTRF
+    old_SEPA_CI: null
+    old_SEPA_additional_position_reference: null
+    original_amount: null
+    posting_text: SEPA-UEBERW
+    prima_nota: 0399
+    purpose: Strukturierter Verwendungszweck EBB 01041 007 DEMTLG:Ggf.Meldevorschriften
+      beachten
+    purpose_code: null
+    recipient_name: null
+    return_debit_notes: null
+    settlement_tag: null
+    status: D
+    transaction_code: '116'
+    transaction_reference: T089414026000002
+  transactions: *id004
+- !!python/object:mt940.models.Transaction
+  data:
+    additional_purpose: null
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '-415603.93'
+      currency: EUR
+    applicant_bin: null
+    applicant_iban: null
+    applicant_name: null
+    bank_reference: 649D24F7C6EDAC53
+    currency: EUR
+    customer_reference: NONREF
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    entry_date: &id055 !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    extra_details: ''
+    funds_code: R
+    guessed_entry_date: *id055
+    id: NTRF
+    posting_text: ONLINE-UEBW.
+    prima_nota: 0399
+    purpose: 'MTLG:SBI-SEPA-SAMMELUEB.Anz:3 Referenz: 1930467116 Erfassung mit 003
+      Zahlungen'
+    recipient_name: null
+    return_debit_notes: null
+    status: D
+    transaction_code: '191'
+    transaction_reference: T089414026000002
+  transactions: *id004
+- !!python/object:mt940.models.Transaction
+  data:
+    FRST_ONE_OFF_RECC: null
+    additional_position_date: null
+    additional_position_reference: null
+    additional_purpose: null
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '-589103.86'
+      currency: EUR
+    applicant_bin: null
+    applicant_creditor_id: null
+    applicant_iban: null
+    applicant_name: null
+    bank_reference: AC59892B266252EC
+    compensation_amount: null
+    currency: EUR
+    customer_reference: 'KREF+
+
+      TFNr 05003 MSGID CTSc-01  BC PPPMTLG:SEPA-Ueberweisungsauftrag Datei mit 0000003
+      Zahlungen'
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    debitor_identifier: null
+    deviate_applicant: null
+    deviate_recipient: null
+    end_to_end_reference: null
+    entry_date: &id056 !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    extra_details: ''
+    funds_code: R
+    guessed_entry_date: *id056
+    gvc_applicant_bin: null
+    gvc_applicant_iban: null
+    id: NTRF
+    old_SEPA_CI: null
+    old_SEPA_additional_position_reference: null
+    original_amount: null
+    posting_text: SEPA-UEBERW
+    prima_nota: 0399
+    purpose: null
+    purpose_code: null
+    recipient_name: null
+    return_debit_notes: null
+    settlement_tag: null
+    status: D
+    transaction_code: '191'
+    transaction_reference: T089414026000002
+  transactions: *id004
+- !!python/object:mt940.models.Transaction
+  data:
+    FRST_ONE_OFF_RECC: null
+    additional_position_date: null
+    additional_position_reference: null
+    additional_purpose: null
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '-915646.88'
+      currency: EUR
+    applicant_bin: null
+    applicant_creditor_id: null
+    applicant_iban: null
+    applicant_name: null
+    bank_reference: CDB988231C851A5B
+    compensation_amount: null
+    currency: EUR
+    customer_reference: 'KREF+
+
+      TFNr 44005 MSGID CTSc-02 EBBMTLG:SEPA-Ueberweisungsauftrag Datei mit 0000002
+      Zahlungen'
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    debitor_identifier: null
+    deviate_applicant: null
+    deviate_recipient: null
+    end_to_end_reference: null
+    entry_date: &id057 !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    extra_details: ''
+    funds_code: R
+    guessed_entry_date: *id057
+    gvc_applicant_bin: null
+    gvc_applicant_iban: null
+    id: NTRF
+    old_SEPA_CI: null
+    old_SEPA_additional_position_reference: null
+    original_amount: null
+    posting_text: SEPA-UEBERW
+    prima_nota: 0399
+    purpose: null
+    purpose_code: null
+    recipient_name: null
+    return_debit_notes: null
+    settlement_tag: null
+    status: D
+    transaction_code: '191'
+    transaction_reference: T089414026000002
+  transactions: *id004
+- !!python/object:mt940.models.Transaction
+  data:
+    FRST_ONE_OFF_RECC: null
+    additional_position_date: null
+    additional_position_reference: null
+    additional_purpose: null
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '16500.07'
+      currency: EUR
+    applicant_bin: null
+    applicant_creditor_id: null
+    applicant_iban: null
+    applicant_name: null
+    bank_reference: '0724710324666001'
+    compensation_amount: null
+    currency: EUR
+    customer_reference: MSGID CTSc-01  B
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    debitor_identifier: null
+    deviate_applicant: null
+    deviate_recipient: null
+    end_to_end_reference: EndToEndId TFNR 05 006 00002MTLG:Grund nicht spezifiziert
+      Reject aus SEPA-Ueberweisungsauftrag
+    entry_date: &id058 !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    extra_details: ''
+    funds_code: R
+    guessed_entry_date: *id058
+    gvc_applicant_bin: null
+    gvc_applicant_iban: null
+    id: NTRF
+    old_SEPA_CI: null
+    old_SEPA_additional_position_reference: null
+    original_amount: null
+    posting_text: RETOURE
+    prima_nota: 0399
+    purpose: null
+    purpose_code: null
+    recipient_name: null
+    return_debit_notes: '914'
+    settlement_tag: null
+    status: C
+    transaction_code: '159'
+    transaction_reference: T089414036000001
+  transactions: *id004
+- !!python/object:mt940.models.Transaction
+  data:
+    FRST_ONE_OFF_RECC: null
+    additional_position_date: null
+    additional_position_reference: null
+    additional_purpose: null
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '154551.93'
+      currency: EUR
+    applicant_bin: null
+    applicant_creditor_id: null
+    applicant_iban: null
+    applicant_name: null
+    bank_reference: '0724710324666006'
+    compensation_amount: null
+    currency: EUR
+    customer_reference: MSGID CTSc-01  B
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    debitor_identifier: null
+    deviate_applicant: null
+    deviate_recipient: null
+    end_to_end_reference: EndToEndId TFNR 05 006 00004MTLG:Grund nicht spezifiziert
+      Reject aus SEPA-Ueberweisungsauftrag
+    entry_date: &id059 !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    extra_details: ''
+    funds_code: R
+    guessed_entry_date: *id059
+    gvc_applicant_bin: null
+    gvc_applicant_iban: null
+    id: NTRF
+    old_SEPA_CI: null
+    old_SEPA_additional_position_reference: null
+    original_amount: null
+    posting_text: RETOURE
+    prima_nota: 0399
+    purpose: null
+    purpose_code: null
+    recipient_name: null
+    return_debit_notes: '914'
+    settlement_tag: null
+    status: C
+    transaction_code: '159'
+    transaction_reference: T089414036000001
+  transactions: *id004
+- !!python/object:mt940.models.Transaction
+  data:
+    FRST_ONE_OFF_RECC: null
+    additional_position_date: null
+    additional_position_reference: null
+    additional_purpose: null
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '-13990.05'
+      currency: EUR
+    applicant_bin: DRESDEFF508
+    applicant_creditor_id: null
+    applicant_iban: DE68508800500194784901
+    applicant_name: Empfaenger Josef Jaeger UK01
+    bank_reference: 0724710333354911
+    compensation_amount: null
+    currency: EUR
+    customer_reference: 'KREF+
+
+      EndToEndId TFNR 21 003 00001'
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    debitor_identifier: null
+    deviate_applicant: null
+    deviate_recipient: null
+    end_to_end_reference: EndToEndId TFNR 21 003 00001
+    entry_date: &id060 !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    extra_details: ''
+    funds_code: R
+    guessed_entry_date: *id060
+    gvc_applicant_bin: null
+    gvc_applicant_iban: null
+    id: NTRF
+    old_SEPA_CI: null
+    old_SEPA_additional_position_reference: null
+    original_amount: null
+    posting_text: ONLINE-UEBW.
+    prima_nota: 0399
+    purpose: 'Verwend CTSc-01 PPP TFNr 21 003MTLG:SBI-SEPA-UEB.DE685088005001 Referenz:
+      1930467122'
+    purpose_code: null
+    recipient_name: null
+    return_debit_notes: null
+    settlement_tag: null
+    status: D
+    transaction_code: '116'
+    transaction_reference: T089414036000001
+  transactions: *id004
+- !!python/object:mt940.models.Transaction
+  data:
+    FRST_ONE_OFF_RECC: null
+    additional_position_date: null
+    additional_position_reference: null
+    additional_purpose: null
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '-19990.05'
+      currency: EUR
+    applicant_bin: DRESDEFF508
+    applicant_creditor_id: null
+    applicant_iban: DE04508800500194781300
+    applicant_name: Empfaenger Gustav Gans
+    bank_reference: 0724710333377198
+    compensation_amount: null
+    currency: EUR
+    customer_reference: 'KREF+
+
+      EndToEndId TFNR 22 001 00001'
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    debitor_identifier: null
+    deviate_applicant: null
+    deviate_recipient: null
+    end_to_end_reference: EndToEndId TFNR 22 001 00001
+    entry_date: &id061 !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    extra_details: ''
+    funds_code: R
+    guessed_entry_date: *id061
+    gvc_applicant_bin: null
+    gvc_applicant_iban: null
+    id: NTRF
+    old_SEPA_CI: null
+    old_SEPA_additional_position_reference: null
+    original_amount: null
+    posting_text: ONLINE-UEBW.
+    prima_nota: 0399
+    purpose: 'Verwend CTSc-01 PPP TFNr 22 001MTLG:SBI-SEPA-UEB.DE045088005001 Referenz:
+      1930467123'
+    purpose_code: null
+    recipient_name: null
+    return_debit_notes: null
+    settlement_tag: null
+    status: D
+    transaction_code: '116'
+    transaction_reference: T089414036000001
+  transactions: *id004
+- !!python/object:mt940.models.Transaction
+  data:
+    FRST_ONE_OFF_RECC: null
+    additional_position_date: null
+    additional_position_reference: null
+    additional_purpose: null
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '-50990.05'
+      currency: EUR
+    applicant_bin: DRESDEFF508
+    applicant_creditor_id: null
+    applicant_iban: DE96508800500194774600
+    applicant_name: Empfaenger Anton Ackermann
+    bank_reference: '0724710324651156'
+    compensation_amount: null
+    currency: EUR
+    customer_reference: 'KREF+
+
+      TFNR 22003 Instruction Id 00001'
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    debitor_identifier: null
+    deviate_applicant: null
+    deviate_recipient: null
+    end_to_end_reference: TFNR 22003 EndToEndId 00001
+    entry_date: &id062 !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    extra_details: ''
+    funds_code: R
+    guessed_entry_date: *id062
+    gvc_applicant_bin: null
+    gvc_applicant_iban: null
+    id: NTRF
+    old_SEPA_CI: null
+    old_SEPA_additional_position_reference: null
+    original_amount: null
+    posting_text: SEPA-UEBERW
+    prima_nota: 0399
+    purpose: Verw CTSc-01 BC-PPP TFNr 22003
+    purpose_code: null
+    recipient_name: null
+    return_debit_notes: null
+    settlement_tag: null
+    status: D
+    transaction_code: '116'
+    transaction_reference: T089414036000001
+  transactions: *id004
+- !!python/object:mt940.models.Transaction
+  data:
+    additional_purpose: null
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '-326609.66'
+      currency: EUR
+    applicant_bin: null
+    applicant_iban: null
+    applicant_name: null
+    bank_reference: 9A4616CC6128D651
+    currency: EUR
+    customer_reference: TFNr 01008 MEBB
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    entry_date: &id063 !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    extra_details: ''
+    funds_code: R
+    guessed_entry_date: *id063
+    id: NTRF
+    posting_text: SEPA-UEBERW
+    prima_nota: 0399
+    purpose: MTLG:SEPA-Ueberweisungsauftrag Datei mit 0000006 Zahlungen
+    recipient_name: null
+    return_debit_notes: null
+    status: D
+    transaction_code: '191'
+    transaction_reference: T089414036000001
+  transactions: *id004
+- !!python/object:mt940.models.Transaction
+  data:
+    FRST_ONE_OFF_RECC: null
+    additional_position_date: null
+    additional_position_reference: null
+    additional_purpose: null
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '-342104'
+      currency: EUR
+    applicant_bin: null
+    applicant_creditor_id: null
+    applicant_iban: null
+    applicant_name: null
+    bank_reference: A26B6D6B5E821EA9
+    compensation_amount: null
+    currency: EUR
+    customer_reference: 'KREF+
+
+      PayId CTSc-01  BC PPP TFNr 05006MTLG:SEPA-Ueberweisungsauftrag Datei mit 0000004
+      Zahlungen'
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    debitor_identifier: null
+    deviate_applicant: null
+    deviate_recipient: null
+    end_to_end_reference: null
+    entry_date: &id064 !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    extra_details: ''
+    funds_code: R
+    guessed_entry_date: *id064
+    gvc_applicant_bin: null
+    gvc_applicant_iban: null
+    id: NTRF
+    old_SEPA_CI: null
+    old_SEPA_additional_position_reference: null
+    original_amount: null
+    posting_text: SEPA-UEBERW
+    prima_nota: 0399
+    purpose: null
+    purpose_code: null
+    recipient_name: null
+    return_debit_notes: null
+    settlement_tag: null
+    status: D
+    transaction_code: '191'
+    transaction_reference: T089414036000002
+  transactions: *id004
+- !!python/object:mt940.models.Transaction
+  data:
+    FRST_ONE_OFF_RECC: null
+    additional_position_date: null
+    additional_position_reference: null
+    additional_purpose: null
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '-962104'
+      currency: EUR
+    applicant_bin: null
+    applicant_creditor_id: null
+    applicant_iban: null
+    applicant_name: null
+    bank_reference: 493189D221858097
+    compensation_amount: null
+    currency: EUR
+    customer_reference: 'KREF+
+
+      TFNr 05009 MSGID CTSc-01 BC-PPPMTLG:SEPA-Ueberweisungsauftrag Datei mit 0000004
+      Zahlungen'
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    debitor_identifier: null
+    deviate_applicant: null
+    deviate_recipient: null
+    end_to_end_reference: null
+    entry_date: &id065 !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    extra_details: ''
+    funds_code: R
+    guessed_entry_date: *id065
+    gvc_applicant_bin: null
+    gvc_applicant_iban: null
+    id: NTRF
+    old_SEPA_CI: null
+    old_SEPA_additional_position_reference: null
+    original_amount: null
+    posting_text: SEPA-UEBERW
+    prima_nota: 0399
+    purpose: null
+    purpose_code: null
+    recipient_name: null
+    return_debit_notes: null
+    settlement_tag: null
+    status: D
+    transaction_code: '191'
+    transaction_reference: T089414036000002
+  transactions: *id004
+- !!python/object:mt940.models.Transaction
+  data:
+    additional_purpose: null
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '-1522104'
+      currency: EUR
+    applicant_bin: null
+    applicant_iban: null
+    applicant_name: null
+    bank_reference: 75C62EC25E19D187
+    currency: EUR
+    customer_reference: NONREF
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    entry_date: &id066 !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    extra_details: ''
+    funds_code: R
+    guessed_entry_date: *id066
+    id: NTRF
+    posting_text: ONLINE-UEBW.
+    prima_nota: 0399
+    purpose: 'MTLG:SBI-SEPA-SAMMELUEB.Anz:4 Referenz: 1930467118 Erfassung mit 004
+      Zahlungen'
+    recipient_name: null
+    return_debit_notes: null
+    status: D
+    transaction_code: '191'
+    transaction_reference: T089414036000002
+  transactions: *id004
+- !!python/object:mt940.models.Transaction
+  data:
+    FRST_ONE_OFF_RECC: null
+    additional_position_date: null
+    additional_position_reference: null
+    additional_purpose: null
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '13990.05'
+      currency: EUR
+    applicant_bin: DRESDEFF508
+    applicant_creditor_id: null
+    applicant_iban: DE95508800500194784900
+    applicant_name: JOSEF        JAEGER
+    bank_reference: 0724710333354911
+    compensation_amount: null
+    currency: EUR
+    customer_reference: NONREF
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    debitor_identifier: null
+    deviate_applicant: null
+    deviate_recipient: null
+    end_to_end_reference: EndToEndId TFNR 21 003 00001
+    entry_date: &id067 !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    extra_details: ''
+    funds_code: R
+    guessed_entry_date: *id067
+    gvc_applicant_bin: null
+    gvc_applicant_iban: null
+    id: NTRF
+    old_SEPA_CI: null
+    old_SEPA_additional_position_reference: null
+    original_amount: null
+    posting_text: GUTSCHRIFT
+    prima_nota: 0399
+    purpose: Verwend CTSc-01 PPP TFNr 21 003
+    purpose_code: null
+    recipient_name: null
+    return_debit_notes: null
+    settlement_tag: null
+    status: C
+    transaction_code: '166'
+    transaction_reference: T089414046000001
+  transactions: *id004
+- !!python/object:mt940.models.Transaction
+  data:
+    FRST_ONE_OFF_RECC: null
+    additional_position_date: null
+    additional_position_reference: null
+    additional_purpose: null
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '-57.34'
+      currency: EUR
+    applicant_bin: SOGEFRPPXXX
+    applicant_creditor_id: null
+    applicant_iban: FR1420041010050500013M02606
+    applicant_name: Empfaenger 1 mit 70 Zeichen Empfaenger 1 mit 70 Zeiche
+    bank_reference: 0724710352971787
+    compensation_amount: null
+    currency: EUR
+    customer_reference: 'KREF+
+
+      TFNR 01015  Instruction Id 00001'
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    debitor_identifier: null
+    deviate_applicant: null
+    deviate_recipient: null
+    end_to_end_reference: TFNR 01015 00001
+    entry_date: &id068 !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    extra_details: ''
+    funds_code: R
+    guessed_entry_date: *id068
+    gvc_applicant_bin: null
+    gvc_applicant_iban: null
+    id: NTRF
+    old_SEPA_CI: null
+    old_SEPA_additional_position_reference: null
+    original_amount: null
+    posting_text: SEPA-UEBERW
+    prima_nota: 0399
+    purpose: Strukturierter Verwendungszweck EBB 01015 001 DE
+    purpose_code: null
+    recipient_name: null
+    return_debit_notes: null
+    settlement_tag: null
+    status: D
+    transaction_code: '116'
+    transaction_reference: T089414056000001
+  transactions: *id004
+- !!python/object:mt940.models.Transaction
+  data:
+    FRST_ONE_OFF_RECC: null
+    additional_position_date: null
+    additional_position_reference: null
+    additional_purpose: null
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '-5002.17'
+      currency: EUR
+    applicant_bin: SOGEFRPPXXX
+    applicant_creditor_id: null
+    applicant_iban: FR1420041010050500013M02606
+    applicant_name: Empfaenger 3 mit 70 Zeichen Empfaenger 3 mit 70 Zeiche
+    bank_reference: 0724710352975390
+    compensation_amount: null
+    currency: EUR
+    customer_reference: 'KREF+
+
+      TFNR 01015  Instruction Id 00003'
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    debitor_identifier: null
+    deviate_applicant: null
+    deviate_recipient: null
+    end_to_end_reference: TFNR 01015 00003
+    entry_date: &id069 !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    extra_details: ''
+    funds_code: R
+    guessed_entry_date: *id069
+    gvc_applicant_bin: null
+    gvc_applicant_iban: null
+    id: NTRF
+    old_SEPA_CI: null
+    old_SEPA_additional_position_reference: null
+    original_amount: null
+    posting_text: SEPA-UEBERW
+    prima_nota: 0399
+    purpose: Strukturierter Verwendungszweck EBB 01015 003 DE
+    purpose_code: null
+    recipient_name: null
+    return_debit_notes: null
+    settlement_tag: null
+    status: D
+    transaction_code: '116'
+    transaction_reference: T089414056000001
+  transactions: *id004
+- !!python/object:mt940.models.Transaction
+  data:
+    FRST_ONE_OFF_RECC: null
+    additional_position_date: null
+    additional_position_reference: null
+    additional_purpose: null
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '-5002.17'
+      currency: EUR
+    applicant_bin: SOGEFRPPXXX
+    applicant_creditor_id: null
+    applicant_iban: FR1420041010050500013M02606
+    applicant_name: Empfaenger 6 mit 70 Zeichen Empfaenger 6 mit 70 Zeiche
+    bank_reference: 0724710352980804
+    compensation_amount: null
+    currency: EUR
+    customer_reference: 'KREF+
+
+      TFNR 01015  Instruction Id 00006'
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    debitor_identifier: null
+    deviate_applicant: null
+    deviate_recipient: null
+    end_to_end_reference: TFNR 01015 00006
+    entry_date: &id070 !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    extra_details: ''
+    funds_code: R
+    guessed_entry_date: *id070
+    gvc_applicant_bin: null
+    gvc_applicant_iban: null
+    id: NTRF
+    old_SEPA_CI: null
+    old_SEPA_additional_position_reference: null
+    original_amount: null
+    posting_text: SEPA-UEBERW
+    prima_nota: 0399
+    purpose: Strukturierter Verwendungszweck EBB 01015 006 DE
+    purpose_code: null
+    recipient_name: null
+    return_debit_notes: null
+    settlement_tag: null
+    status: D
+    transaction_code: '116'
+    transaction_reference: T089414056000001
+  transactions: *id004
+- !!python/object:mt940.models.Transaction
+  data:
+    FRST_ONE_OFF_RECC: null
+    additional_position_date: null
+    additional_position_reference: null
+    additional_purpose: null
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '-5002.17'
+      currency: EUR
+    applicant_bin: SOGEFRPPXXX
+    applicant_creditor_id: null
+    applicant_iban: FR1420041010050500013M02606
+    applicant_name: Empfaenger 5 mit 70 Zeichen Empfaenger 5 mit 70 Zeiche
+    bank_reference: 0724710352979070
+    compensation_amount: null
+    currency: EUR
+    customer_reference: 'KREF+
+
+      TFNR 01015  Instruction Id 00005'
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    debitor_identifier: null
+    deviate_applicant: null
+    deviate_recipient: null
+    end_to_end_reference: TFNR 01015 00005
+    entry_date: &id071 !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    extra_details: ''
+    funds_code: R
+    guessed_entry_date: *id071
+    gvc_applicant_bin: null
+    gvc_applicant_iban: null
+    id: NTRF
+    old_SEPA_CI: null
+    old_SEPA_additional_position_reference: null
+    original_amount: null
+    posting_text: SEPA-UEBERW
+    prima_nota: 0399
+    purpose: Strukturierter Verwendungszweck EBB 01015 005 DE
+    purpose_code: null
+    recipient_name: null
+    return_debit_notes: null
+    settlement_tag: null
+    status: D
+    transaction_code: '116'
+    transaction_reference: T089414056000001
+  transactions: *id004
+- !!python/object:mt940.models.Transaction
+  data:
+    FRST_ONE_OFF_RECC: null
+    additional_position_date: null
+    additional_position_reference: null
+    additional_purpose: null
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '-5002.17'
+      currency: EUR
+    applicant_bin: SOGEFRPPXXX
+    applicant_creditor_id: null
+    applicant_iban: FR1420041010050500013M02606
+    applicant_name: Empfaenger 2 mit 70 Zeichen Empfaenger 2 mit 70 Zeiche
+    bank_reference: 0724710352973502
+    compensation_amount: null
+    currency: EUR
+    customer_reference: 'KREF+
+
+      TFNR 01015  Instruction Id 00002'
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    debitor_identifier: null
+    deviate_applicant: null
+    deviate_recipient: null
+    end_to_end_reference: TFNR 01015 00002
+    entry_date: &id072 !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    extra_details: ''
+    funds_code: R
+    guessed_entry_date: *id072
+    gvc_applicant_bin: null
+    gvc_applicant_iban: null
+    id: NTRF
+    old_SEPA_CI: null
+    old_SEPA_additional_position_reference: null
+    original_amount: null
+    posting_text: SEPA-UEBERW
+    prima_nota: 0399
+    purpose: Strukturierter Verwendungszweck EBB 01015 002 DE
+    purpose_code: null
+    recipient_name: null
+    return_debit_notes: null
+    settlement_tag: null
+    status: D
+    transaction_code: '116'
+    transaction_reference: T089414056000001
+  transactions: *id004
+- !!python/object:mt940.models.Transaction
+  data:
+    FRST_ONE_OFF_RECC: null
+    additional_position_date: null
+    additional_position_reference: null
+    additional_purpose: null
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '-5002.17'
+      currency: EUR
+    applicant_bin: SOGEFRPPXXX
+    applicant_creditor_id: null
+    applicant_iban: FR1420041010050500013M02606
+    applicant_name: Empfaenger 4 mit 70 Zeichen Empfaenger 4 mit 70 Zeiche
+    bank_reference: 0724710352977271
+    compensation_amount: null
+    currency: EUR
+    customer_reference: 'KREF+
+
+      TFNR 01015  Instruction Id 00004'
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    debitor_identifier: null
+    deviate_applicant: null
+    deviate_recipient: null
+    end_to_end_reference: TFNR 01015 00004
+    entry_date: &id073 !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    extra_details: ''
+    funds_code: R
+    guessed_entry_date: *id073
+    gvc_applicant_bin: null
+    gvc_applicant_iban: null
+    id: NTRF
+    old_SEPA_CI: null
+    old_SEPA_additional_position_reference: null
+    original_amount: null
+    posting_text: SEPA-UEBERW
+    prima_nota: 0399
+    purpose: Strukturierter Verwendungszweck EBB 01015 004 DE
+    purpose_code: null
+    recipient_name: null
+    return_debit_notes: null
+    settlement_tag: null
+    status: D
+    transaction_code: '116'
+    transaction_reference: T089414056000002
+  transactions: *id004
+- !!python/object:mt940.models.Transaction
+  data:
+    FRST_ONE_OFF_RECC: null
+    additional_position_date: null
+    additional_position_reference: null
+    additional_purpose: null
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '-19990.05'
+      currency: EUR
+    applicant_bin: DRESDEFF508
+    applicant_creditor_id: null
+    applicant_iban: DE12508800500194786200
+    applicant_name: Empfaenger Ludwig Loewe
+    bank_reference: '0724710333360224'
+    compensation_amount: null
+    currency: EUR
+    customer_reference: 'KREF+
+
+      EndToEndId TFNR 22 002 00001'
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    debitor_identifier: null
+    deviate_applicant: null
+    deviate_recipient: null
+    end_to_end_reference: EndToEndId TFNR 22 002 00001
+    entry_date: &id074 !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    extra_details: ''
+    funds_code: R
+    guessed_entry_date: *id074
+    gvc_applicant_bin: null
+    gvc_applicant_iban: null
+    id: NTRF
+    old_SEPA_CI: null
+    old_SEPA_additional_position_reference: null
+    original_amount: null
+    posting_text: ONLINE-UEBW.
+    prima_nota: 0399
+    purpose: 'Verwend CTSc-01 PPP TFNr 22 002MTLG:SBI-SEPA-UEB.DE125088005001 Referenz:
+      1930467119'
+    purpose_code: null
+    recipient_name: null
+    return_debit_notes: null
+    settlement_tag: null
+    status: D
+    transaction_code: '116'
+    transaction_reference: T089414056000002
+  transactions: *id004
+- !!python/object:mt940.models.Transaction
+  data:
+    FRST_ONE_OFF_RECC: null
+    additional_position_date: null
+    additional_position_reference: null
+    additional_purpose: null
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '-50990.05'
+      currency: EUR
+    applicant_bin: DRESDEFF508
+    applicant_creditor_id: null
+    applicant_iban: DE84508800500194785001
+    applicant_name: Empfanger Karl Kaufmann UK01
+    bank_reference: 0724710352952868
+    compensation_amount: null
+    currency: EUR
+    customer_reference: 'KREF+
+
+      TFNR 21007 Instruction Id 00001'
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    debitor_identifier: null
+    deviate_applicant: null
+    deviate_recipient: null
+    end_to_end_reference: TFNR 21007 EndToEndId 00001
+    entry_date: &id075 !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    extra_details: ''
+    funds_code: R
+    guessed_entry_date: *id075
+    gvc_applicant_bin: null
+    gvc_applicant_iban: null
+    id: NTRF
+    old_SEPA_CI: null
+    old_SEPA_additional_position_reference: null
+    original_amount: null
+    posting_text: SEPA-UEBERW
+    prima_nota: 0399
+    purpose: Verwend CTSc-01 eBB TFNr 21007
+    purpose_code: null
+    recipient_name: null
+    return_debit_notes: null
+    settlement_tag: null
+    status: D
+    transaction_code: '116'
+    transaction_reference: T089414056000002
+  transactions: *id004
+- !!python/object:mt940.models.Transaction
+  data:
+    FRST_ONE_OFF_RECC: null
+    additional_position_date: null
+    additional_position_reference: null
+    additional_purpose: null
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '-50990.05'
+      currency: EUR
+    applicant_bin: DRESDEFF508
+    applicant_creditor_id: null
+    applicant_iban: DE10508800500194787400
+    applicant_name: Empfaenger Marta Metzger
+    bank_reference: '0724710333343453'
+    compensation_amount: null
+    currency: EUR
+    customer_reference: 'KREF+
+
+      EndToEndId TFNR 22 004 00001'
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    debitor_identifier: null
+    deviate_applicant: null
+    deviate_recipient: null
+    end_to_end_reference: EndToEndId TFNR 22 004 00001
+    entry_date: &id076 !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    extra_details: ''
+    funds_code: R
+    guessed_entry_date: *id076
+    gvc_applicant_bin: null
+    gvc_applicant_iban: null
+    id: NTRF
+    old_SEPA_CI: null
+    old_SEPA_additional_position_reference: null
+    original_amount: null
+    posting_text: ONLINE-UEBW.
+    prima_nota: 0399
+    purpose: 'Verw CTSc-01 BC-PPP TFNr 22 004MTLG:SBI-SEPA-UEB.DE105088005001 Referenz:
+      1930467120'
+    purpose_code: null
+    recipient_name: null
+    return_debit_notes: null
+    settlement_tag: null
+    status: D
+    transaction_code: '116'
+    transaction_reference: T089414056000002
+  transactions: *id004
+- !!python/object:mt940.models.Transaction
+  data:
+    FRST_ONE_OFF_RECC: null
+    additional_position_date: null
+    additional_position_reference: null
+    additional_purpose: null
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '-55344.11'
+      currency: EUR
+    applicant_bin: SOGEFRPPXXX
+    applicant_creditor_id: null
+    applicant_iban: FR1420041010050500013M02606
+    applicant_name: Empfaenger 7 mit 70 Zeichen Empfaenger 7 mit 70 Zeiche
+    bank_reference: 0724710352982472
+    compensation_amount: null
+    currency: EUR
+    customer_reference: 'KREF+
+
+      TFNR 01015  Instruction Id 00007'
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    debitor_identifier: null
+    deviate_applicant: null
+    deviate_recipient: null
+    end_to_end_reference: TFNR 01015 00007
+    entry_date: &id077 !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    extra_details: ''
+    funds_code: R
+    guessed_entry_date: *id077
+    gvc_applicant_bin: null
+    gvc_applicant_iban: null
+    id: NTRF
+    old_SEPA_CI: null
+    old_SEPA_additional_position_reference: null
+    original_amount: null
+    posting_text: SEPA-UEBERW
+    prima_nota: 0399
+    purpose: Strukturierter Verwendungszweck EBB 01015 007 DEMTLG:Ggf.Meldevorschriften
+      beachten
+    purpose_code: null
+    recipient_name: null
+    return_debit_notes: null
+    settlement_tag: null
+    status: D
+    transaction_code: '116'
+    transaction_reference: T089414056000002
+  transactions: *id004
+- !!python/object:mt940.models.Transaction
+  data:
+    FRST_ONE_OFF_RECC: null
+    additional_position_date: null
+    additional_position_reference: null
+    additional_purpose: null
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '-342104'
+      currency: EUR
+    applicant_bin: null
+    applicant_creditor_id: null
+    applicant_iban: null
+    applicant_name: null
+    bank_reference: D4AF9E363A92E76F
+    compensation_amount: null
+    currency: EUR
+    customer_reference: 'KREF+
+
+      TFNr 05005 PayId CTSc-01  BC PPPMTLG:SEPA-Ueberweisungsauftrag Datei mit 0000004
+      Zahlungen'
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    debitor_identifier: null
+    deviate_applicant: null
+    deviate_recipient: null
+    end_to_end_reference: null
+    entry_date: &id078 !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    extra_details: ''
+    funds_code: R
+    guessed_entry_date: *id078
+    gvc_applicant_bin: null
+    gvc_applicant_iban: null
+    id: NTRF
+    old_SEPA_CI: null
+    old_SEPA_additional_position_reference: null
+    original_amount: null
+    posting_text: SEPA-UEBERW
+    prima_nota: 0399
+    purpose: null
+    purpose_code: null
+    recipient_name: null
+    return_debit_notes: null
+    settlement_tag: null
+    status: D
+    transaction_code: '191'
+    transaction_reference: T089414056000003
+  transactions: *id004
+- !!python/object:mt940.models.Transaction
+  data:
+    FRST_ONE_OFF_RECC: null
+    additional_position_date: null
+    additional_position_reference: null
+    additional_purpose: 'MTLG:SBI-SEPA-UEB.FR142004101005 Referenz: 1930467117Ggf.Meldevorschriften
+      beachten'
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '-956588.05'
+      currency: EUR
+    applicant_bin: SOGEFRPPXXX
+    applicant_creditor_id: null
+    applicant_iban: FR1420041010050500013M02606
+    applicant_name: Empfaenger 1
+    bank_reference: '0724710333366624'
+    compensation_amount: null
+    currency: EUR
+    customer_reference: 'KREF+
+
+      EndToEndId TFNR 06 003 00001'
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    debitor_identifier: null
+    deviate_applicant: null
+    deviate_recipient: null
+    end_to_end_reference: EndToEndId TFNR 06 003 00001
+    entry_date: &id079 !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    extra_details: ''
+    funds_code: R
+    guessed_entry_date: *id079
+    gvc_applicant_bin: null
+    gvc_applicant_iban: null
+    id: NTRF
+    old_SEPA_CI: null
+    old_SEPA_additional_position_reference: null
+    original_amount: null
+    posting_text: ONLINE-UEBW.
+    prima_nota: 0399
+    purpose: Unstrukturiert Verwendungs/zweck mit 140 Stellenfur /SEPA ZKA Buchungsschema
+      A-/CT-PTS-S01 A-CT-ENTNRZ-S01/ CTSc-01 BC PPP TFNr 06 003/0001
+    purpose_code: null
+    recipient_name: null
+    return_debit_notes: null
+    settlement_tag: null
+    status: D
+    transaction_code: '116'
+    transaction_reference: T089414056000003
+  transactions: *id004
+- !!python/object:mt940.models.Transaction
+  data:
+    FRST_ONE_OFF_RECC: null
+    additional_position_date: null
+    additional_position_reference: null
+    additional_purpose: null
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '50990.05'
+      currency: EUR
+    applicant_bin: DRESDEFF508
+    applicant_creditor_id: null
+    applicant_iban: DE14508800500194785000
+    applicant_name: Karl Kaufmann
+    bank_reference: 0724710352952868
+    compensation_amount: null
+    currency: EUR
+    customer_reference: NONREF
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    debitor_identifier: null
+    deviate_applicant: null
+    deviate_recipient: null
+    end_to_end_reference: TFNR 21007 EndToEndId 00001
+    entry_date: &id080 !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    extra_details: ''
+    funds_code: R
+    guessed_entry_date: *id080
+    gvc_applicant_bin: null
+    gvc_applicant_iban: null
+    id: NTRF
+    old_SEPA_CI: null
+    old_SEPA_additional_position_reference: null
+    original_amount: null
+    posting_text: GUTSCHRIFT
+    prima_nota: 0399
+    purpose: Verwend CTSc-01 eBB TFNr 21007
+    purpose_code: null
+    recipient_name: null
+    return_debit_notes: null
+    settlement_tag: null
+    status: C
+    transaction_code: '166'
+    transaction_reference: T089414066000001
+  transactions: *id004
+- !!python/object:mt940.models.Transaction
+  data:
+    FRST_ONE_OFF_RECC: null
+    additional_position_date: null
+    additional_position_reference: null
+    additional_purpose: null
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '16500.07'
+      currency: EUR
+    applicant_bin: DRESDEFF508
+    applicant_creditor_id: null
+    applicant_iban: DE14508800500194785000
+    applicant_name: Karl Kaufmann
+    bank_reference: 0724710324661086
+    compensation_amount: null
+    currency: EUR
+    customer_reference: NONREF
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    debitor_identifier: null
+    deviate_applicant: null
+    deviate_recipient: null
+    end_to_end_reference: TFNR 0500500002
+    entry_date: &id081 !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    extra_details: ''
+    funds_code: R
+    guessed_entry_date: *id081
+    gvc_applicant_bin: null
+    gvc_applicant_iban: null
+    id: NTRF
+    old_SEPA_CI: null
+    old_SEPA_additional_position_reference: null
+    original_amount: null
+    posting_text: GUTSCHRIFT
+    prima_nota: 0399
+    purpose: Strukturierter Verwendungszweck 50050002 DE
+    purpose_code: null
+    recipient_name: null
+    return_debit_notes: null
+    settlement_tag: null
+    status: C
+    transaction_code: '166'
+    transaction_reference: T089414076000001
+  transactions: *id004
+- !!python/object:mt940.models.Transaction
+  data:
+    FRST_ONE_OFF_RECC: null
+    additional_position_date: null
+    additional_position_reference: null
+    additional_purpose: null
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '19990.05'
+      currency: EUR
+    applicant_bin: DRESDEFF508
+    applicant_creditor_id: null
+    applicant_iban: DE14508800500194785000
+    applicant_name: KARL        KAUFMANN
+    bank_reference: '0724710333360224'
+    compensation_amount: null
+    currency: EUR
+    customer_reference: NONREF
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    debitor_identifier: null
+    deviate_applicant: null
+    deviate_recipient: null
+    end_to_end_reference: EndToEndId TFNR 22 002 00001
+    entry_date: &id082 !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    extra_details: ''
+    funds_code: R
+    guessed_entry_date: *id082
+    gvc_applicant_bin: null
+    gvc_applicant_iban: null
+    id: NTRF
+    old_SEPA_CI: null
+    old_SEPA_additional_position_reference: null
+    original_amount: null
+    posting_text: GUTSCHRIFT
+    prima_nota: 0399
+    purpose: Verwend CTSc-01 PPP TFNr 22 002
+    purpose_code: null
+    recipient_name: null
+    return_debit_notes: null
+    settlement_tag: null
+    status: C
+    transaction_code: '166'
+    transaction_reference: T089414076000001
+  transactions: *id004
+- !!python/object:mt940.models.Transaction
+  data:
+    FRST_ONE_OFF_RECC: null
+    additional_position_date: null
+    additional_position_reference: null
+    additional_purpose: null
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '56500.07'
+      currency: EUR
+    applicant_bin: DRESDEFF508
+    applicant_creditor_id: null
+    applicant_iban: DE03508800500194791600
+    applicant_name: Quentin Quast
+    bank_reference: '0724710324647446'
+    compensation_amount: null
+    currency: EUR
+    customer_reference: NONREF
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    debitor_identifier: null
+    deviate_applicant: null
+    deviate_recipient: null
+    end_to_end_reference: TFNR 0300300002
+    entry_date: &id083 !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    extra_details: ''
+    funds_code: R
+    guessed_entry_date: *id083
+    gvc_applicant_bin: null
+    gvc_applicant_iban: null
+    id: NTRF
+    old_SEPA_CI: null
+    old_SEPA_additional_position_reference: null
+    original_amount: null
+    posting_text: GUTSCHRIFT
+    prima_nota: 0399
+    purpose: Strukturierter Verwendungszweck 30030002 DE
+    purpose_code: null
+    recipient_name: null
+    return_debit_notes: null
+    settlement_tag: null
+    status: C
+    transaction_code: '166'
+    transaction_reference: T089414076000001
+  transactions: *id004
+- !!python/object:mt940.models.Transaction
+  data:
+    FRST_ONE_OFF_RECC: null
+    additional_position_date: null
+    additional_position_reference: null
+    additional_purpose: null
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '50990.05'
+      currency: EUR
+    applicant_bin: DRESDEFF508
+    applicant_creditor_id: null
+    applicant_iban: DE14508800500194785000
+    applicant_name: KARL        KAUFMANN
+    bank_reference: '0724710333343453'
+    compensation_amount: null
+    currency: EUR
+    customer_reference: NONREF
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBw==
+    debitor_identifier: null
+    deviate_applicant: null
+    deviate_recipient: null
+    end_to_end_reference: EndToEndId TFNR 22 004 00001
+    entry_date: &id084 !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    extra_details: ''
+    funds_code: R
+    guessed_entry_date: *id084
+    gvc_applicant_bin: null
+    gvc_applicant_iban: null
+    id: NTRF
+    old_SEPA_CI: null
+    old_SEPA_additional_position_reference: null
+    original_amount: null
+    posting_text: GUTSCHRIFT
+    prima_nota: 0399
+    purpose: Verw CTSc-01 BC-PPP TFNr 22 004
+    purpose_code: null
+    recipient_name: null
+    return_debit_notes: null
+    settlement_tag: null
+    status: C
+    transaction_code: '166'
+    transaction_reference: T089414086000001
+  transactions: *id004
+- !!python/object:mt940.models.Transaction
+  data:
+    FRST_ONE_OFF_RECC: null
+    additional_position_date: null
+    additional_position_reference: null
+    additional_purpose: null
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '154551.93'
+      currency: EUR
+    applicant_bin: DRESDEFF508
+    applicant_creditor_id: null
+    applicant_iban: DE03508800500194791600
+    applicant_name: Quentin Quast
+    bank_reference: '0724710324647450'
+    compensation_amount: null
+    currency: EUR
+    customer_reference: NONREF
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBw==
+    debitor_identifier: null
+    deviate_applicant: null
+    deviate_recipient: null
+    end_to_end_reference: TFNR 0300300004
+    entry_date: &id085 !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    extra_details: ''
+    funds_code: R
+    guessed_entry_date: *id085
+    gvc_applicant_bin: null
+    gvc_applicant_iban: null
+    id: NTRF
+    old_SEPA_CI: null
+    old_SEPA_additional_position_reference: null
+    original_amount: null
+    posting_text: GUTSCHRIFT
+    prima_nota: 0399
+    purpose: Strukturierter Verwendungszweck 30030004 DE
+    purpose_code: null
+    recipient_name: null
+    return_debit_notes: null
+    settlement_tag: null
+    status: C
+    transaction_code: '166'
+    transaction_reference: T089414086000001
+  transactions: *id004
+- !!python/object:mt940.models.Transaction
+  data:
+    FRST_ONE_OFF_RECC: null
+    additional_position_date: null
+    additional_position_reference: null
+    additional_purpose: null
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '154551.93'
+      currency: EUR
+    applicant_bin: DRESDEFF508
+    applicant_creditor_id: null
+    applicant_iban: DE14508800500194785000
+    applicant_name: Karl Kaufmann
+    bank_reference: 0724710324661090
+    compensation_amount: null
+    currency: EUR
+    customer_reference: NONREF
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBw==
+    debitor_identifier: null
+    deviate_applicant: null
+    deviate_recipient: null
+    end_to_end_reference: TFNR 0500500004
+    entry_date: &id086 !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    extra_details: ''
+    funds_code: R
+    guessed_entry_date: *id086
+    gvc_applicant_bin: null
+    gvc_applicant_iban: null
+    id: NTRF
+    old_SEPA_CI: null
+    old_SEPA_additional_position_reference: null
+    original_amount: null
+    posting_text: GUTSCHRIFT
+    prima_nota: 0399
+    purpose: Strukturierter Verwendungszweck 50050004 DE
+    purpose_code: null
+    recipient_name: null
+    return_debit_notes: null
+    settlement_tag: null
+    status: C
+    transaction_code: '166'
+    transaction_reference: T089414086000001
+  transactions: *id004
+- !!python/object:mt940.models.Transaction
+  data:
+    FRST_ONE_OFF_RECC: null
+    additional_position_date: null
+    additional_position_reference: null
+    additional_purpose: null
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '-1500'
+      currency: EUR
+    applicant_bin: null
+    applicant_creditor_id: null
+    applicant_iban: null
+    applicant_name: null
+    bank_reference: 536D80EFEC56ACF8
+    compensation_amount: null
+    currency: EUR
+    customer_reference: 'KREF+
+
+      TFNr 01022 MSGID CTSc-01 EBBMTLG:SEPA-Ueberweisungsauftrag Datei mit 0000001
+      Zahlungen'
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    debitor_identifier: null
+    deviate_applicant: null
+    deviate_recipient: null
+    end_to_end_reference: null
+    entry_date: &id087 !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    extra_details: ''
+    funds_code: R
+    guessed_entry_date: *id087
+    gvc_applicant_bin: null
+    gvc_applicant_iban: null
+    id: NTRF
+    old_SEPA_CI: null
+    old_SEPA_additional_position_reference: null
+    original_amount: null
+    posting_text: SEPA-UEBERW
+    prima_nota: 0399
+    purpose: null
+    purpose_code: null
+    recipient_name: null
+    return_debit_notes: null
+    settlement_tag: null
+    status: D
+    transaction_code: '191'
+    transaction_reference: T089414086000001
+  transactions: *id004
+- !!python/object:mt940.models.Transaction
+  data:
+    FRST_ONE_OFF_RECC: null
+    additional_position_date: null
+    additional_position_reference: null
+    additional_purpose: null
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '300'
+      currency: EUR
+    applicant_bin: null
+    applicant_creditor_id: null
+    applicant_iban: null
+    applicant_name: null
+    bank_reference: '0724710345316116'
+    compensation_amount: null
+    currency: EUR
+    customer_reference: TFNr 40001 MSGID
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    debitor_identifier: null
+    deviate_applicant: null
+    deviate_recipient: null
+    end_to_end_reference: TFNR 40001 00005MTLG:Grund nicht spezifiziert Reject aus
+      SEPA-Ueberweisungsauftrag
+    entry_date: &id088 !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    extra_details: ''
+    funds_code: R
+    guessed_entry_date: *id088
+    gvc_applicant_bin: null
+    gvc_applicant_iban: null
+    id: NTRF
+    old_SEPA_CI: null
+    old_SEPA_additional_position_reference: null
+    original_amount: null
+    posting_text: RETOURE
+    prima_nota: 0399
+    purpose: null
+    purpose_code: null
+    recipient_name: null
+    return_debit_notes: '914'
+    settlement_tag: null
+    status: C
+    transaction_code: '159'
+    transaction_reference: T089414096000001
+  transactions: *id004
+- !!python/object:mt940.models.Transaction
+  data:
+    FRST_ONE_OFF_RECC: null
+    additional_position_date: null
+    additional_position_reference: null
+    additional_purpose: null
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '335.33'
+      currency: EUR
+    applicant_bin: null
+    applicant_creditor_id: null
+    applicant_iban: null
+    applicant_name: null
+    bank_reference: '0724710351063401'
+    compensation_amount: null
+    currency: EUR
+    customer_reference: TFNr 44001 MSGID
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    debitor_identifier: null
+    deviate_applicant: null
+    deviate_recipient: null
+    end_to_end_reference: TFNR 44001 00001MTLG:Grund nicht spezifiziert Reject aus
+      SEPA-Ueberweisungsauftrag
+    entry_date: &id089 !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    extra_details: ''
+    funds_code: R
+    guessed_entry_date: *id089
+    gvc_applicant_bin: null
+    gvc_applicant_iban: null
+    id: NTRF
+    old_SEPA_CI: null
+    old_SEPA_additional_position_reference: null
+    original_amount: null
+    posting_text: RETOURE
+    prima_nota: 0399
+    purpose: null
+    purpose_code: null
+    recipient_name: null
+    return_debit_notes: '914'
+    settlement_tag: null
+    status: C
+    transaction_code: '159'
+    transaction_reference: T089414096000001
+  transactions: *id004
+- !!python/object:mt940.models.Transaction
+  data:
+    FRST_ONE_OFF_RECC: null
+    additional_position_date: null
+    additional_position_reference: null
+    additional_purpose: null
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '15000'
+      currency: EUR
+    applicant_bin: null
+    applicant_creditor_id: null
+    applicant_iban: null
+    applicant_name: null
+    bank_reference: '0724710345316110'
+    compensation_amount: null
+    currency: EUR
+    customer_reference: TFNr 40001 MSGID
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    debitor_identifier: null
+    deviate_applicant: null
+    deviate_recipient: null
+    end_to_end_reference: TFNR 40001 00002MTLG:Grund nicht spezifiziert Reject aus
+      SEPA-Ueberweisungsauftrag
+    entry_date: &id090 !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    extra_details: ''
+    funds_code: R
+    guessed_entry_date: *id090
+    gvc_applicant_bin: null
+    gvc_applicant_iban: null
+    id: NTRF
+    old_SEPA_CI: null
+    old_SEPA_additional_position_reference: null
+    original_amount: null
+    posting_text: RETOURE
+    prima_nota: 0399
+    purpose: null
+    purpose_code: null
+    recipient_name: null
+    return_debit_notes: '914'
+    settlement_tag: null
+    status: C
+    transaction_code: '159'
+    transaction_reference: T089414096000001
+  transactions: *id004
+- !!python/object:mt940.models.Transaction
+  data:
+    FRST_ONE_OFF_RECC: null
+    additional_position_date: null
+    additional_position_reference: null
+    additional_purpose: null
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '15000.05'
+      currency: EUR
+    applicant_bin: PBNKDEFF100
+    applicant_creditor_id: null
+    applicant_iban: DE42100100100043921105
+    applicant_name: Richter Renate 70 Zeichen Beginn Fuellzeichen xxxxxxxx
+    bank_reference: 0724710290659857
+    compensation_amount: null
+    currency: EUR
+    customer_reference: NONREF
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    debitor_identifier: null
+    deviate_applicant: null
+    deviate_recipient: null
+    end_to_end_reference: EndToEndIdTFNR2000100001
+    entry_date: &id091 !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    extra_details: ''
+    funds_code: R
+    guessed_entry_date: *id091
+    gvc_applicant_bin: null
+    gvc_applicant_iban: null
+    id: NTRF
+    old_SEPA_CI: null
+    old_SEPA_additional_position_reference: null
+    original_amount: null
+    posting_text: GUTSCHRIFT
+    prima_nota: 0399
+    purpose: TO 13 TFNr 20001 Eingangskanal Mint Unstrukturierter Verwendungszweck
+      140 Zeichen Beginn Fuellzeichen xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+    purpose_code: null
+    recipient_name: null
+    return_debit_notes: null
+    settlement_tag: null
+    status: C
+    transaction_code: '166'
+    transaction_reference: T089414096000001
+  transactions: *id004
+- !!python/object:mt940.models.Transaction
+  data:
+    FRST_ONE_OFF_RECC: null
+    additional_position_date: null
+    additional_position_reference: null
+    additional_purpose: null
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '125004.88'
+      currency: EUR
+    applicant_bin: PBNKDEFF100
+    applicant_creditor_id: null
+    applicant_iban: DE42100100100043921105
+    applicant_name: Richter Renate 70 Zeichen Beginn Fuellzeichen xxxxxxxx
+    bank_reference: 0724710290624796
+    compensation_amount: null
+    currency: EUR
+    customer_reference: NONREF
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    debitor_identifier: null
+    deviate_applicant: null
+    deviate_recipient: null
+    end_to_end_reference: null
+    entry_date: &id092 !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    extra_details: ''
+    funds_code: R
+    guessed_entry_date: *id092
+    gvc_applicant_bin: null
+    gvc_applicant_iban: null
+    id: NTRF
+    old_SEPA_CI: null
+    old_SEPA_additional_position_reference: null
+    original_amount: null
+    posting_text: GUTSCHRIFT
+    prima_nota: 0399
+    purpose: TO13 TF20005 MINT
+    purpose_code: null
+    recipient_name: null
+    return_debit_notes: null
+    settlement_tag: null
+    status: C
+    transaction_code: '166'
+    transaction_reference: T089414096000001
+  transactions: *id004
+- !!python/object:mt940.models.Transaction
+  data:
+    FRST_ONE_OFF_RECC: null
+    additional_position_date: null
+    additional_position_reference: null
+    additional_purpose: null
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '915311.55'
+      currency: EUR
+    applicant_bin: null
+    applicant_creditor_id: null
+    applicant_iban: null
+    applicant_name: null
+    bank_reference: R724710351063405
+    compensation_amount: null
+    currency: EUR
+    customer_reference: TFNr 44001 MSGID
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    debitor_identifier: null
+    deviate_applicant: null
+    deviate_recipient: null
+    end_to_end_reference: TFNR 44001 00002MTLG:IBAN ungueltig Rueckueberweisung aus
+      SEPA-Ueberweisungsauftrag
+    entry_date: &id093 !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    extra_details: ''
+    funds_code: R
+    guessed_entry_date: *id093
+    gvc_applicant_bin: null
+    gvc_applicant_iban: null
+    id: NTRF
+    old_SEPA_CI: null
+    old_SEPA_additional_position_reference: null
+    original_amount: null
+    posting_text: RETOURE
+    prima_nota: 0399
+    purpose: null
+    purpose_code: null
+    recipient_name: null
+    return_debit_notes: '901'
+    settlement_tag: null
+    status: C
+    transaction_code: '159'
+    transaction_reference: T089414096000001
+  transactions: *id004
+- !!python/object:mt940.models.Transaction
+  data:
+    additional_purpose: null
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '-3572569.03'
+      currency: EUR
+    applicant_bin: null
+    applicant_iban: null
+    applicant_name: null
+    bank_reference: null
+    currency: EUR
+    customer_reference: NONREF
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    entry_date: &id094 !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    extra_details: ''
+    funds_code: R
+    guessed_entry_date: *id094
+    id: NMSC
+    posting_text: SAMMLER
+    prima_nota: '9800'
+    purpose: 0904059001
+    recipient_name: null
+    return_debit_notes: null
+    status: D
+    transaction_code: 079
+    transaction_reference: T089414096000001
+  transactions: *id004
+- !!python/object:mt940.models.Transaction
+  data:
+    FRST_ONE_OFF_RECC: null
+    additional_position_date: null
+    additional_position_reference: null
+    additional_purpose: null
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '1910.05'
+      currency: EUR
+    applicant_bin: DRESDEFF508
+    applicant_creditor_id: null
+    applicant_iban: DE03508800500194791600
+    applicant_name: QUENTIN        QUAST
+    bank_reference: 0724710333345079
+    compensation_amount: null
+    currency: EUR
+    customer_reference: NONREF
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    debitor_identifier: null
+    deviate_applicant: null
+    deviate_recipient: null
+    end_to_end_reference: TFNR 21001 EndToEndId 00001
+    entry_date: &id095 !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    extra_details: ''
+    funds_code: R
+    guessed_entry_date: *id095
+    gvc_applicant_bin: null
+    gvc_applicant_iban: null
+    id: NTRF
+    old_SEPA_CI: null
+    old_SEPA_additional_position_reference: null
+    original_amount: null
+    posting_text: GUTSCHRIFT
+    prima_nota: 0399
+    purpose: Verwend CTSc-01 FFP TFNr 21 001
+    purpose_code: null
+    recipient_name: null
+    return_debit_notes: null
+    settlement_tag: null
+    status: C
+    transaction_code: '166'
+    transaction_reference: T089414106000001
+  transactions: *id004
+- !!python/object:mt940.models.Transaction
+  data:
+    FRST_ONE_OFF_RECC: null
+    additional_position_date: null
+    additional_position_reference: null
+    additional_purpose: null
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '50990.05'
+      currency: EUR
+    applicant_bin: DRESDEFF508
+    applicant_creditor_id: null
+    applicant_iban: DE03508800500194791600
+    applicant_name: Quentin Quast
+    bank_reference: 0724710352956584
+    compensation_amount: null
+    currency: EUR
+    customer_reference: NONREF
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    debitor_identifier: null
+    deviate_applicant: null
+    deviate_recipient: null
+    end_to_end_reference: TFNR 21004 EndToEndId 00001
+    entry_date: &id096 !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    extra_details: ''
+    funds_code: R
+    guessed_entry_date: *id096
+    gvc_applicant_bin: null
+    gvc_applicant_iban: null
+    id: NTRF
+    old_SEPA_CI: null
+    old_SEPA_additional_position_reference: null
+    original_amount: null
+    posting_text: GUTSCHRIFT
+    prima_nota: 0399
+    purpose: Verwend CTSc-01 eBB TFNr 21004
+    purpose_code: null
+    recipient_name: null
+    return_debit_notes: null
+    settlement_tag: null
+    status: C
+    transaction_code: '166'
+    transaction_reference: T089414106000001
+  transactions: *id004
+- !!python/object:mt940.models.Transaction
+  data:
+    FRST_ONE_OFF_RECC: null
+    additional_position_date: null
+    additional_position_reference: null
+    additional_purpose: null
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '-125300.1'
+      currency: EUR
+    applicant_bin: null
+    applicant_creditor_id: null
+    applicant_iban: null
+    applicant_name: null
+    bank_reference: F2CA963F5C750549
+    compensation_amount: null
+    currency: EUR
+    customer_reference: 'KREF+
+
+      TFNr 03005 MSGID CTSc-01 FFPMTLG:SEPA-Ueberweisungsauftrag Datei mit 0000001
+      Zahlungen'
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    debitor_identifier: null
+    deviate_applicant: null
+    deviate_recipient: null
+    end_to_end_reference: null
+    entry_date: &id097 !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    extra_details: ''
+    funds_code: R
+    guessed_entry_date: *id097
+    gvc_applicant_bin: null
+    gvc_applicant_iban: null
+    id: NTRF
+    old_SEPA_CI: null
+    old_SEPA_additional_position_reference: null
+    original_amount: null
+    posting_text: SEPA-UEBERW
+    prima_nota: 0399
+    purpose: null
+    purpose_code: null
+    recipient_name: null
+    return_debit_notes: null
+    settlement_tag: null
+    status: D
+    transaction_code: '191'
+    transaction_reference: T089414106000001
+  transactions: *id004
+- !!python/object:mt940.models.Transaction
+  data:
+    FRST_ONE_OFF_RECC: null
+    additional_position_date: null
+    additional_position_reference: null
+    additional_purpose: null
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '-150'
+      currency: EUR
+    applicant_bin: null
+    applicant_creditor_id: null
+    applicant_iban: null
+    applicant_name: null
+    bank_reference: FFCD94B7601B6E06
+    compensation_amount: null
+    currency: EUR
+    customer_reference: 'KREF+
+
+      TFNr 01031 PayId CTSc-01 EBBMTLG:SEPA-Ueberweisungsauftrag Datei mit 0000001
+      Zahlungen'
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    debitor_identifier: null
+    deviate_applicant: null
+    deviate_recipient: null
+    end_to_end_reference: null
+    entry_date: &id098 !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    extra_details: ''
+    funds_code: R
+    guessed_entry_date: *id098
+    gvc_applicant_bin: null
+    gvc_applicant_iban: null
+    id: NTRF
+    old_SEPA_CI: null
+    old_SEPA_additional_position_reference: null
+    original_amount: null
+    posting_text: SEPA-UEBERW
+    prima_nota: 0399
+    purpose: null
+    purpose_code: null
+    recipient_name: null
+    return_debit_notes: null
+    settlement_tag: null
+    status: D
+    transaction_code: '191'
+    transaction_reference: T089414116000001
+  transactions: *id004
+- !!python/object:mt940.models.Transaction
+  data:
+    FRST_ONE_OFF_RECC: null
+    additional_position_date: null
+    additional_position_reference: null
+    additional_purpose: null
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '-150'
+      currency: EUR
+    applicant_bin: null
+    applicant_creditor_id: null
+    applicant_iban: null
+    applicant_name: null
+    bank_reference: DED4A9D0CA11033B
+    compensation_amount: null
+    currency: EUR
+    customer_reference: 'KREF+
+
+      TFNr 01032 PayId CTSc-01 EBBMTLG:SEPA-Ueberweisungsauftrag Datei mit 0000001
+      Zahlungen'
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    debitor_identifier: null
+    deviate_applicant: null
+    deviate_recipient: null
+    end_to_end_reference: null
+    entry_date: &id099 !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    extra_details: ''
+    funds_code: R
+    guessed_entry_date: *id099
+    gvc_applicant_bin: null
+    gvc_applicant_iban: null
+    id: NTRF
+    old_SEPA_CI: null
+    old_SEPA_additional_position_reference: null
+    original_amount: null
+    posting_text: SEPA-UEBERW
+    prima_nota: 0399
+    purpose: null
+    purpose_code: null
+    recipient_name: null
+    return_debit_notes: null
+    settlement_tag: null
+    status: D
+    transaction_code: '191'
+    transaction_reference: T089414126000001
+  transactions: *id004
+- !!python/object:mt940.models.Transaction
+  data:
+    FRST_ONE_OFF_RECC: null
+    additional_position_date: null
+    additional_position_reference: null
+    additional_purpose: null
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '50.05'
+      currency: EUR
+    applicant_bin: DRESDEFF508
+    applicant_creditor_id: null
+    applicant_iban: DE51508800500190038900
+    applicant_name: Richter Renate 70 Zeichen Beginn Fuellzeichen xxxxxxxx
+    bank_reference: 0724710290648274
+    compensation_amount: null
+    currency: EUR
+    customer_reference: NONREF
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    debitor_identifier: null
+    deviate_applicant: null
+    deviate_recipient: null
+    end_to_end_reference: EndToEndIdTFNR5000500001
+    entry_date: &id100 !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    extra_details: ''
+    funds_code: R
+    guessed_entry_date: *id100
+    gvc_applicant_bin: null
+    gvc_applicant_iban: null
+    id: NTRF
+    old_SEPA_CI: null
+    old_SEPA_additional_position_reference: null
+    original_amount: null
+    posting_text: GUTSCHRIFT
+    prima_nota: 0399
+    purpose: TO 25 TFNr 50005 Eingangskanal Mint Unstrukturierter Verwendungszweck
+      140 Zeichen Beginn Fuellzeichen xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+    purpose_code: null
+    recipient_name: null
+    return_debit_notes: null
+    settlement_tag: null
+    status: C
+    transaction_code: '166'
+    transaction_reference: T089414136000001
+  transactions: *id004

--- a/mt940_tests/betterplace/sepa_mt9401.yml
+++ b/mt940_tests/betterplace/sepa_mt9401.yml
@@ -49,6 +49,18 @@ data:
   sequence_number: '00001'
   statement_number: '00001'
   transaction_reference: T089414136000001
+options: !!python/object/new:mt940.options.Options
+  state:
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
 tags:
   13: !!python/object:mt940.tags.DateTimeIndication
     re: !!python/object/apply:re._compile
@@ -146,12 +158,11 @@ transactions:
       currency: EUR
     applicant_bin: null
     applicant_creditor_id: null
-    applicant_iban: null
     applicant_name: null
     bank_reference: 0724710345313905
     compensation_amount: null
     currency: EUR
-    customer_reference: TFNr 40005 MSGID
+    customer_reference: null
     date: !!python/object/apply:mt940.models.Date
     - !!binary |
       B9cJBA==
@@ -195,12 +206,11 @@ transactions:
       currency: EUR
     applicant_bin: null
     applicant_creditor_id: null
-    applicant_iban: null
     applicant_name: null
     bank_reference: 0724710351061491
     compensation_amount: null
     currency: EUR
-    customer_reference: TFNr 44003 MSGID
+    customer_reference: null
     date: !!python/object/apply:mt940.models.Date
     - !!binary |
       B9cJBA==
@@ -244,12 +254,11 @@ transactions:
       currency: EUR
     applicant_bin: null
     applicant_creditor_id: null
-    applicant_iban: null
     applicant_name: null
     bank_reference: 0724710345313900
     compensation_amount: null
     currency: EUR
-    customer_reference: TFNr 40005 MSGID
+    customer_reference: null
     date: !!python/object/apply:mt940.models.Date
     - !!binary |
       B9cJBA==
@@ -289,7 +298,6 @@ transactions:
       - '66295.08'
       currency: EUR
     applicant_bin: null
-    applicant_iban: null
     applicant_name: null
     bank_reference: null
     currency: EUR
@@ -325,12 +333,11 @@ transactions:
       currency: EUR
     applicant_bin: null
     applicant_creditor_id: null
-    applicant_iban: null
     applicant_name: null
     bank_reference: R724710351061495
     compensation_amount: null
     currency: EUR
-    customer_reference: TFNr 44003 MSGID
+    customer_reference: null
     date: !!python/object/apply:mt940.models.Date
     - !!binary |
       B9cJBA==
@@ -367,10 +374,9 @@ transactions:
     additional_purpose: null
     amount: !!python/object:mt940.models.Amount
       amount: !!python/object/apply:decimal.Decimal
-      - '-204.88'
+      - '204.88'
       currency: EUR
     applicant_bin: null
-    applicant_iban: null
     applicant_name: null
     bank_reference: null
     currency: EUR
@@ -402,7 +408,6 @@ transactions:
       - '-999946.95'
       currency: EUR
     applicant_bin: null
-    applicant_iban: null
     applicant_name: null
     bank_reference: null
     currency: EUR
@@ -438,12 +443,12 @@ transactions:
       currency: EUR
     applicant_bin: PBNKDEFF100
     applicant_creditor_id: null
-    applicant_iban: DE42100100100043921105
-    applicant_name: Richter Renate 70 Zeichen Beginn Fuellzeichen xxxxxxxx
+    applicant_name: DE42100100100043921105Richter Renate 70 Zeichen Beginn Fuellzeichen
+      xxxxxxxx
     bank_reference: 0724710290621954
     compensation_amount: null
     currency: EUR
-    customer_reference: NONREF
+    customer_reference: null
     date: !!python/object/apply:mt940.models.Date
     - !!binary |
       B9cJBA==
@@ -487,7 +492,6 @@ transactions:
       currency: EUR
     applicant_bin: null
     applicant_creditor_id: null
-    applicant_iban: null
     applicant_name: null
     bank_reference: BD7CFA74485E7E69
     compensation_amount: null
@@ -538,12 +542,11 @@ transactions:
       currency: EUR
     applicant_bin: PBNKDEFF100
     applicant_creditor_id: null
-    applicant_iban: DE42100100100043921105
-    applicant_name: Richter Renate 70 Zeichen Beginn Fuellzeichenxxxxxxxx
+    applicant_name: DE42100100100043921105Richter Renate 70 Zeichen Beginn Fuellzeichenxxxxxxxx
     bank_reference: 0724710290658244
     compensation_amount: null
     currency: EUR
-    customer_reference: NONREF
+    customer_reference: null
     date: !!python/object/apply:mt940.models.Date
     - !!binary |
       B9cJBA==
@@ -586,12 +589,12 @@ transactions:
       currency: EUR
     applicant_bin: NIKACH22XXX
     applicant_creditor_id: null
-    applicant_iban: CH8500779014054431109
-    applicant_name: Cornelia Prochownik 70 Zeichen BeginnFuellzeichen xxx
+    applicant_name: CH8500779014054431109Cornelia Prochownik 70 Zeichen BeginnFuellzeichen
+      xxx
     bank_reference: 0724710290635078
     compensation_amount: null
     currency: EUR
-    customer_reference: NONREF
+    customer_reference: null
     date: !!python/object/apply:mt940.models.Date
     - !!binary |
       B9cJBA==
@@ -634,12 +637,12 @@ transactions:
       currency: EUR
     applicant_bin: UBSWCHZH80A
     applicant_creditor_id: null
-    applicant_iban: CH6500279279C31180700
-    applicant_name: Richter Renate 70 Zeichen Beginn Fuellzeichen xxxxxxxx
+    applicant_name: CH6500279279C31180700Richter Renate 70 Zeichen Beginn Fuellzeichen
+      xxxxxxxx
     bank_reference: 0724710290626371
     compensation_amount: null
     currency: EUR
-    customer_reference: NONREF
+    customer_reference: null
     date: !!python/object/apply:mt940.models.Date
     - !!binary |
       B9cJBA==
@@ -682,7 +685,6 @@ transactions:
       currency: EUR
     applicant_bin: null
     applicant_creditor_id: null
-    applicant_iban: null
     applicant_name: null
     bank_reference: DE85920B84F8E98D
     compensation_amount: null
@@ -733,7 +735,6 @@ transactions:
       currency: EUR
     applicant_bin: null
     applicant_creditor_id: null
-    applicant_iban: null
     applicant_name: null
     bank_reference: D1C08A4EB4664146
     compensation_amount: null
@@ -784,12 +785,12 @@ transactions:
       currency: EUR
     applicant_bin: PBNKDEFF250
     applicant_creditor_id: null
-    applicant_iban: DE40250100300325207300
-    applicant_name: Daniel Severidt 70 ZeichenBeginn Fuellzeichen xxxxxxx
+    applicant_name: DE40250100300325207300Daniel Severidt 70 ZeichenBeginn Fuellzeichen
+      xxxxxxx
     bank_reference: 0724710290628244
     compensation_amount: null
     currency: EUR
-    customer_reference: NONREF
+    customer_reference: null
     date: !!python/object/apply:mt940.models.Date
     - !!binary |
       B9cJBA==
@@ -832,12 +833,12 @@ transactions:
       currency: EUR
     applicant_bin: PBNKDEFF100
     applicant_creditor_id: null
-    applicant_iban: DE40100100100000214105
-    applicant_name: Cornelia Prochownik 70 Zeichen Beginn Fuellzeichen xxx
+    applicant_name: DE40100100100000214105Cornelia Prochownik 70 Zeichen Beginn Fuellzeichen
+      xxx
     bank_reference: 0724710290631813
     compensation_amount: null
     currency: EUR
-    customer_reference: NONREF
+    customer_reference: null
     date: !!python/object/apply:mt940.models.Date
     - !!binary |
       B9cJBA==
@@ -880,12 +881,12 @@ transactions:
       currency: EUR
     applicant_bin: PBNKDEFF250
     applicant_creditor_id: null
-    applicant_iban: DE39250100300172064300
-    applicant_name: Dirk Leunig 70 Zeichen Beginn Fuellzeichen xxxxxxxxxxx
+    applicant_name: DE39250100300172064300Dirk Leunig 70 Zeichen Beginn Fuellzeichen
+      xxxxxxxxxxx
     bank_reference: 0724710290630146
     compensation_amount: null
     currency: EUR
-    customer_reference: NONREF
+    customer_reference: null
     date: !!python/object/apply:mt940.models.Date
     - !!binary |
       B9cJBA==
@@ -924,7 +925,6 @@ transactions:
       - '204.88'
       currency: EUR
     applicant_bin: null
-    applicant_iban: null
     applicant_name: null
     bank_reference: null
     currency: EUR
@@ -953,10 +953,9 @@ transactions:
     additional_purpose: null
     amount: !!python/object:mt940.models.Amount
       amount: !!python/object/apply:decimal.Decimal
-      - '-204.88'
+      - '204.88'
       currency: EUR
     applicant_bin: null
-    applicant_iban: null
     applicant_name: null
     bank_reference: R724710290656678
     currency: EUR
@@ -992,8 +991,7 @@ transactions:
       currency: EUR
     applicant_bin: DRESDEFF508
     applicant_creditor_id: null
-    applicant_iban: DE76508800500194780101
-    applicant_name: Empfaenger Florian Frech UK 01
+    applicant_name: DE76508800500194780101Empfaenger Florian Frech UK 01
     bank_reference: 0724710352954937
     compensation_amount: null
     currency: EUR
@@ -1042,7 +1040,6 @@ transactions:
       currency: EUR
     applicant_bin: null
     applicant_creditor_id: null
-    applicant_iban: null
     applicant_name: null
     bank_reference: 8AE3169901918BD3
     compensation_amount: null
@@ -1089,7 +1086,6 @@ transactions:
       - '-500250'
       currency: EUR
     applicant_bin: null
-    applicant_iban: null
     applicant_name: null
     bank_reference: E87048E11B394C1E
     currency: EUR
@@ -1125,12 +1121,11 @@ transactions:
       currency: EUR
     applicant_bin: DRESDEFF508
     applicant_creditor_id: null
-    applicant_iban: DE06508800500194780100
-    applicant_name: Florian Frech
+    applicant_name: DE06508800500194780100Florian Frech
     bank_reference: 0724710352954937
     compensation_amount: null
     currency: EUR
-    customer_reference: NONREF
+    customer_reference: null
     date: !!python/object/apply:mt940.models.Date
     - !!binary |
       B9cJBA==
@@ -1173,12 +1168,11 @@ transactions:
       currency: EUR
     applicant_bin: DRESDEFF508
     applicant_creditor_id: null
-    applicant_iban: DE95508800500194784900
-    applicant_name: JOSEF        JAEGER
+    applicant_name: DE95508800500194784900JOSEF        JAEGER
     bank_reference: 0724710333377198
     compensation_amount: null
     currency: EUR
-    customer_reference: NONREF
+    customer_reference: null
     date: !!python/object/apply:mt940.models.Date
     - !!binary |
       B9cJBA==
@@ -1222,8 +1216,8 @@ transactions:
       currency: EUR
     applicant_bin: SOGEFRPPXXX
     applicant_creditor_id: null
-    applicant_iban: FR1420041010050500013M02606
-    applicant_name: Empfaenger 1 mit 70 Zeichen Empfaenger 1 mit 70 Zeiche
+    applicant_name: FR1420041010050500013M02606Empfaenger 1 mit 70 Zeichen Empfaenger
+      1 mit 70 Zeiche
     bank_reference: 0724710352996674
     compensation_amount: null
     currency: EUR
@@ -1273,12 +1267,12 @@ transactions:
       currency: EUR
     applicant_bin: SOGEFRPPXXX
     applicant_creditor_id: null
-    applicant_iban: FR1420041010050500013M02606
-    applicant_name: Empfaenger 6mit 70 Zeichen Empfaenger 6 mit 70 Zeiche
+    applicant_name: FR1420041010050500013M02606Empfaenger 6mit 70 Zeichen Empfaenger
+      6 mit 70 Zeiche
     bank_reference: 0724710353006393
     compensation_amount: null
     currency: EUR
-    customer_reference: TFNr 01011 MSGID
+    customer_reference: null
     date: !!python/object/apply:mt940.models.Date
     - !!binary |
       B9cJBA==
@@ -1322,8 +1316,8 @@ transactions:
       currency: EUR
     applicant_bin: SOGEFRPPXXX
     applicant_creditor_id: null
-    applicant_iban: FR1420041010050500013M02606
-    applicant_name: Empfaenger 2 mit 70 Zeichen Empfaenger 2 mit 70 Zeiche
+    applicant_name: FR1420041010050500013M02606Empfaenger 2 mit 70 Zeichen Empfaenger
+      2 mit 70 Zeiche
     bank_reference: 0724710352998444
     compensation_amount: null
     currency: EUR
@@ -1373,8 +1367,8 @@ transactions:
       currency: EUR
     applicant_bin: SOGEFRPPXXX
     applicant_creditor_id: null
-    applicant_iban: FR1420041010050500013M02606
-    applicant_name: Empfaenger 4 mit 70 Zeichen Empfaenger 4 mit 70 Zeiche
+    applicant_name: FR1420041010050500013M02606Empfaenger 4 mit 70 Zeichen Empfaenger
+      4 mit 70 Zeiche
     bank_reference: 0724710353002818
     compensation_amount: null
     currency: EUR
@@ -1424,8 +1418,8 @@ transactions:
       currency: EUR
     applicant_bin: SOGEFRPPXXX
     applicant_creditor_id: null
-    applicant_iban: FR1420041010050500013M02606
-    applicant_name: Empfaenger 3 mit 70 Zeichen Empfaenger 3 mit 70 Zeiche
+    applicant_name: FR1420041010050500013M02606Empfaenger 3 mit 70 Zeichen Empfaenger
+      3 mit 70 Zeiche
     bank_reference: 0724710353000284
     compensation_amount: null
     currency: EUR
@@ -1475,8 +1469,8 @@ transactions:
       currency: EUR
     applicant_bin: SOGEFRPPXXX
     applicant_creditor_id: null
-    applicant_iban: FR1420041010050500013M02606
-    applicant_name: Empfaenger 5 mit 70 Zeichen Empfaenger 5 mit 70 Zeiche
+    applicant_name: FR1420041010050500013M02606Empfaenger 5 mit 70 Zeichen Empfaenger
+      5 mit 70 Zeiche
     bank_reference: 0724710353004695
     compensation_amount: null
     currency: EUR
@@ -1526,8 +1520,8 @@ transactions:
       currency: EUR
     applicant_bin: SOGEFRPPXXX
     applicant_creditor_id: null
-    applicant_iban: FR1420041010050500013M02606
-    applicant_name: Empfaenger 7 mit 70 Zeichen Empfaenger 7 mit 70 Zeiche
+    applicant_name: FR1420041010050500013M02606Empfaenger 7 mit 70 Zeichen Empfaenger
+      7 mit 70 Zeiche
     bank_reference: 0724710353008994
     compensation_amount: null
     currency: EUR
@@ -1577,12 +1571,11 @@ transactions:
       currency: EUR
     applicant_bin: null
     applicant_creditor_id: null
-    applicant_iban: null
     applicant_name: null
     bank_reference: 0724710324649377
     compensation_amount: null
     currency: EUR
-    customer_reference: TFNr 40016 MSGID
+    customer_reference: null
     date: !!python/object/apply:mt940.models.Date
     - !!binary |
       B9cJBA==
@@ -1626,12 +1619,11 @@ transactions:
       currency: EUR
     applicant_bin: null
     applicant_creditor_id: null
-    applicant_iban: null
     applicant_name: null
     bank_reference: 0724710345347489
     compensation_amount: null
     currency: EUR
-    customer_reference: MCCT070927000002
+    customer_reference: null
     date: !!python/object/apply:mt940.models.Date
     - !!binary |
       B9cJBA==
@@ -1675,12 +1667,11 @@ transactions:
       currency: EUR
     applicant_bin: null
     applicant_creditor_id: null
-    applicant_iban: null
     applicant_name: null
     bank_reference: '0724710351065632'
     compensation_amount: null
     currency: EUR
-    customer_reference: MCCT070927000004
+    customer_reference: null
     date: !!python/object/apply:mt940.models.Date
     - !!binary |
       B9cJBA==
@@ -1724,7 +1715,6 @@ transactions:
       currency: EUR
     applicant_bin: null
     applicant_creditor_id: null
-    applicant_iban: null
     applicant_name: null
     bank_reference: '0724710333347237'
     compensation_amount: null
@@ -1774,7 +1764,6 @@ transactions:
       currency: EUR
     applicant_bin: null
     applicant_creditor_id: null
-    applicant_iban: null
     applicant_name: null
     bank_reference: '0724710333347241'
     compensation_amount: null
@@ -1824,7 +1813,6 @@ transactions:
       currency: EUR
     applicant_bin: null
     applicant_creditor_id: null
-    applicant_iban: null
     applicant_name: null
     bank_reference: 31408CF87AD5901E
     compensation_amount: null
@@ -1871,7 +1859,6 @@ transactions:
       - '-2550.12'
       currency: EUR
     applicant_bin: null
-    applicant_iban: null
     applicant_name: null
     bank_reference: 4F112D73FF96F4FB
     currency: EUR
@@ -1903,7 +1890,6 @@ transactions:
       - '-2550.12'
       currency: EUR
     applicant_bin: null
-    applicant_iban: null
     applicant_name: null
     bank_reference: EC4BA14CEA34BFF3
     currency: EUR
@@ -1935,7 +1921,6 @@ transactions:
       - '-65500.15'
       currency: EUR
     applicant_bin: null
-    applicant_iban: null
     applicant_name: null
     bank_reference: 92D891C454BC30B5
     currency: EUR
@@ -1968,7 +1953,6 @@ transactions:
       - '-402104'
       currency: EUR
     applicant_bin: null
-    applicant_iban: null
     applicant_name: null
     bank_reference: 57B4197CC644DE8F
     currency: EUR
@@ -2005,7 +1989,6 @@ transactions:
       currency: EUR
     applicant_bin: null
     applicant_creditor_id: null
-    applicant_iban: null
     applicant_name: null
     bank_reference: 06F8672B28B7A92F
     compensation_amount: null
@@ -2056,12 +2039,11 @@ transactions:
       currency: EUR
     applicant_bin: null
     applicant_creditor_id: null
-    applicant_iban: null
     applicant_name: null
     bank_reference: 0724710351059240
     compensation_amount: null
     currency: EUR
-    customer_reference: TFNr 44005 MSGID
+    customer_reference: null
     date: !!python/object/apply:mt940.models.Date
     - !!binary |
       B9cJBA==
@@ -2105,12 +2087,11 @@ transactions:
       currency: EUR
     applicant_bin: null
     applicant_creditor_id: null
-    applicant_iban: null
     applicant_name: null
     bank_reference: R724710351059243
     compensation_amount: null
     currency: EUR
-    customer_reference: TFNr 44005 MSGID
+    customer_reference: null
     date: !!python/object/apply:mt940.models.Date
     - !!binary |
       B9cJBA==
@@ -2154,8 +2135,8 @@ transactions:
       currency: EUR
     applicant_bin: SOGEFRPPXXX
     applicant_creditor_id: null
-    applicant_iban: FR1420041010050500013M02606
-    applicant_name: Empfaenger 1 mit 70 Zeichen Empfaenger 1 mit 70 Zeiche
+    applicant_name: FR1420041010050500013M02606Empfaenger 1 mit 70 Zeichen Empfaenger
+      1 mit 70 Zeiche
     bank_reference: 0724710360914647
     compensation_amount: null
     currency: EUR
@@ -2204,8 +2185,8 @@ transactions:
       currency: EUR
     applicant_bin: SOGEFRPPXXX
     applicant_creditor_id: null
-    applicant_iban: FR1420041010050500013M02606
-    applicant_name: Empfaenger 2 mit 70 Zeichen Empfaenger 2 mit 70 Zeiche
+    applicant_name: FR1420041010050500013M02606Empfaenger 2 mit 70 Zeichen Empfaenger
+      2 mit 70 Zeiche
     bank_reference: 0724710360912501
     compensation_amount: null
     currency: EUR
@@ -2254,8 +2235,8 @@ transactions:
       currency: EUR
     applicant_bin: SOGEFRPPXXX
     applicant_creditor_id: null
-    applicant_iban: FR1420041010050500013M02606
-    applicant_name: Empfaenger 5 mit 70 Zeichen Empfaenger 5 mit 70 Zeiche
+    applicant_name: FR1420041010050500013M02606Empfaenger 5 mit 70 Zeichen Empfaenger
+      5 mit 70 Zeiche
     bank_reference: 0724710360923556
     compensation_amount: null
     currency: EUR
@@ -2304,8 +2285,8 @@ transactions:
       currency: EUR
     applicant_bin: SOGEFRPPXXX
     applicant_creditor_id: null
-    applicant_iban: FR1420041010050500013M02606
-    applicant_name: Empfaenger 6 mit 70 Zeichen Empfaenger 6 mit 70 Zeiche
+    applicant_name: FR1420041010050500013M02606Empfaenger 6 mit 70 Zeichen Empfaenger
+      6 mit 70 Zeiche
     bank_reference: 0724710360910575
     compensation_amount: null
     currency: EUR
@@ -2354,8 +2335,8 @@ transactions:
       currency: EUR
     applicant_bin: SOGEFRPPXXX
     applicant_creditor_id: null
-    applicant_iban: FR1420041010050500013M02606
-    applicant_name: Empfaenger 4 mit 70 Zeichen Empfaenger 4 mit 70 Zeiche
+    applicant_name: FR1420041010050500013M02606Empfaenger 4 mit 70 Zeichen Empfaenger
+      4 mit 70 Zeiche
     bank_reference: 0724710360918027
     compensation_amount: null
     currency: EUR
@@ -2404,8 +2385,8 @@ transactions:
       currency: EUR
     applicant_bin: SOGEFRPPXXX
     applicant_creditor_id: null
-    applicant_iban: FR1420041010050500013M02606
-    applicant_name: Empfaenger 3 mit 70 Zeichen Empfaenger 3 mit 70 Zeiche
+    applicant_name: FR1420041010050500013M02606Empfaenger 3 mit 70 Zeichen Empfaenger
+      3 mit 70 Zeiche
     bank_reference: 0724710360916341
     compensation_amount: null
     currency: EUR
@@ -2454,8 +2435,8 @@ transactions:
       currency: EUR
     applicant_bin: SOGEFRPPXXX
     applicant_creditor_id: null
-    applicant_iban: FR1420041010050500013M02606
-    applicant_name: Empfaenger 7 mit 70 Zeichen Empfaenger 7 mit 70 Zeiche
+    applicant_name: FR1420041010050500013M02606Empfaenger 7 mit 70 Zeichen Empfaenger
+      7 mit 70 Zeiche
     bank_reference: 0724710360908674
     compensation_amount: null
     currency: EUR
@@ -2501,7 +2482,6 @@ transactions:
       - '-415603.93'
       currency: EUR
     applicant_bin: null
-    applicant_iban: null
     applicant_name: null
     bank_reference: 649D24F7C6EDAC53
     currency: EUR
@@ -2538,7 +2518,6 @@ transactions:
       currency: EUR
     applicant_bin: null
     applicant_creditor_id: null
-    applicant_iban: null
     applicant_name: null
     bank_reference: AC59892B266252EC
     compensation_amount: null
@@ -2589,7 +2568,6 @@ transactions:
       currency: EUR
     applicant_bin: null
     applicant_creditor_id: null
-    applicant_iban: null
     applicant_name: null
     bank_reference: CDB988231C851A5B
     compensation_amount: null
@@ -2640,12 +2618,11 @@ transactions:
       currency: EUR
     applicant_bin: null
     applicant_creditor_id: null
-    applicant_iban: null
     applicant_name: null
     bank_reference: '0724710324666001'
     compensation_amount: null
     currency: EUR
-    customer_reference: MSGID CTSc-01  B
+    customer_reference: null
     date: !!python/object/apply:mt940.models.Date
     - !!binary |
       B9cJBA==
@@ -2689,12 +2666,11 @@ transactions:
       currency: EUR
     applicant_bin: null
     applicant_creditor_id: null
-    applicant_iban: null
     applicant_name: null
     bank_reference: '0724710324666006'
     compensation_amount: null
     currency: EUR
-    customer_reference: MSGID CTSc-01  B
+    customer_reference: null
     date: !!python/object/apply:mt940.models.Date
     - !!binary |
       B9cJBA==
@@ -2738,8 +2714,7 @@ transactions:
       currency: EUR
     applicant_bin: DRESDEFF508
     applicant_creditor_id: null
-    applicant_iban: DE68508800500194784901
-    applicant_name: Empfaenger Josef Jaeger UK01
+    applicant_name: DE68508800500194784901Empfaenger Josef Jaeger UK01
     bank_reference: 0724710333354911
     compensation_amount: null
     currency: EUR
@@ -2789,8 +2764,7 @@ transactions:
       currency: EUR
     applicant_bin: DRESDEFF508
     applicant_creditor_id: null
-    applicant_iban: DE04508800500194781300
-    applicant_name: Empfaenger Gustav Gans
+    applicant_name: DE04508800500194781300Empfaenger Gustav Gans
     bank_reference: 0724710333377198
     compensation_amount: null
     currency: EUR
@@ -2840,8 +2814,7 @@ transactions:
       currency: EUR
     applicant_bin: DRESDEFF508
     applicant_creditor_id: null
-    applicant_iban: DE96508800500194774600
-    applicant_name: Empfaenger Anton Ackermann
+    applicant_name: DE96508800500194774600Empfaenger Anton Ackermann
     bank_reference: '0724710324651156'
     compensation_amount: null
     currency: EUR
@@ -2886,7 +2859,6 @@ transactions:
       - '-326609.66'
       currency: EUR
     applicant_bin: null
-    applicant_iban: null
     applicant_name: null
     bank_reference: 9A4616CC6128D651
     currency: EUR
@@ -2922,7 +2894,6 @@ transactions:
       currency: EUR
     applicant_bin: null
     applicant_creditor_id: null
-    applicant_iban: null
     applicant_name: null
     bank_reference: A26B6D6B5E821EA9
     compensation_amount: null
@@ -2973,7 +2944,6 @@ transactions:
       currency: EUR
     applicant_bin: null
     applicant_creditor_id: null
-    applicant_iban: null
     applicant_name: null
     bank_reference: 493189D221858097
     compensation_amount: null
@@ -3020,7 +2990,6 @@ transactions:
       - '-1522104'
       currency: EUR
     applicant_bin: null
-    applicant_iban: null
     applicant_name: null
     bank_reference: 75C62EC25E19D187
     currency: EUR
@@ -3057,12 +3026,11 @@ transactions:
       currency: EUR
     applicant_bin: DRESDEFF508
     applicant_creditor_id: null
-    applicant_iban: DE95508800500194784900
-    applicant_name: JOSEF        JAEGER
+    applicant_name: DE95508800500194784900JOSEF        JAEGER
     bank_reference: 0724710333354911
     compensation_amount: null
     currency: EUR
-    customer_reference: NONREF
+    customer_reference: null
     date: !!python/object/apply:mt940.models.Date
     - !!binary |
       B9cJBA==
@@ -3105,8 +3073,8 @@ transactions:
       currency: EUR
     applicant_bin: SOGEFRPPXXX
     applicant_creditor_id: null
-    applicant_iban: FR1420041010050500013M02606
-    applicant_name: Empfaenger 1 mit 70 Zeichen Empfaenger 1 mit 70 Zeiche
+    applicant_name: FR1420041010050500013M02606Empfaenger 1 mit 70 Zeichen Empfaenger
+      1 mit 70 Zeiche
     bank_reference: 0724710352971787
     compensation_amount: null
     currency: EUR
@@ -3155,8 +3123,8 @@ transactions:
       currency: EUR
     applicant_bin: SOGEFRPPXXX
     applicant_creditor_id: null
-    applicant_iban: FR1420041010050500013M02606
-    applicant_name: Empfaenger 3 mit 70 Zeichen Empfaenger 3 mit 70 Zeiche
+    applicant_name: FR1420041010050500013M02606Empfaenger 3 mit 70 Zeichen Empfaenger
+      3 mit 70 Zeiche
     bank_reference: 0724710352975390
     compensation_amount: null
     currency: EUR
@@ -3205,8 +3173,8 @@ transactions:
       currency: EUR
     applicant_bin: SOGEFRPPXXX
     applicant_creditor_id: null
-    applicant_iban: FR1420041010050500013M02606
-    applicant_name: Empfaenger 6 mit 70 Zeichen Empfaenger 6 mit 70 Zeiche
+    applicant_name: FR1420041010050500013M02606Empfaenger 6 mit 70 Zeichen Empfaenger
+      6 mit 70 Zeiche
     bank_reference: 0724710352980804
     compensation_amount: null
     currency: EUR
@@ -3255,8 +3223,8 @@ transactions:
       currency: EUR
     applicant_bin: SOGEFRPPXXX
     applicant_creditor_id: null
-    applicant_iban: FR1420041010050500013M02606
-    applicant_name: Empfaenger 5 mit 70 Zeichen Empfaenger 5 mit 70 Zeiche
+    applicant_name: FR1420041010050500013M02606Empfaenger 5 mit 70 Zeichen Empfaenger
+      5 mit 70 Zeiche
     bank_reference: 0724710352979070
     compensation_amount: null
     currency: EUR
@@ -3305,8 +3273,8 @@ transactions:
       currency: EUR
     applicant_bin: SOGEFRPPXXX
     applicant_creditor_id: null
-    applicant_iban: FR1420041010050500013M02606
-    applicant_name: Empfaenger 2 mit 70 Zeichen Empfaenger 2 mit 70 Zeiche
+    applicant_name: FR1420041010050500013M02606Empfaenger 2 mit 70 Zeichen Empfaenger
+      2 mit 70 Zeiche
     bank_reference: 0724710352973502
     compensation_amount: null
     currency: EUR
@@ -3355,8 +3323,8 @@ transactions:
       currency: EUR
     applicant_bin: SOGEFRPPXXX
     applicant_creditor_id: null
-    applicant_iban: FR1420041010050500013M02606
-    applicant_name: Empfaenger 4 mit 70 Zeichen Empfaenger 4 mit 70 Zeiche
+    applicant_name: FR1420041010050500013M02606Empfaenger 4 mit 70 Zeichen Empfaenger
+      4 mit 70 Zeiche
     bank_reference: 0724710352977271
     compensation_amount: null
     currency: EUR
@@ -3405,8 +3373,7 @@ transactions:
       currency: EUR
     applicant_bin: DRESDEFF508
     applicant_creditor_id: null
-    applicant_iban: DE12508800500194786200
-    applicant_name: Empfaenger Ludwig Loewe
+    applicant_name: DE12508800500194786200Empfaenger Ludwig Loewe
     bank_reference: '0724710333360224'
     compensation_amount: null
     currency: EUR
@@ -3456,8 +3423,7 @@ transactions:
       currency: EUR
     applicant_bin: DRESDEFF508
     applicant_creditor_id: null
-    applicant_iban: DE84508800500194785001
-    applicant_name: Empfanger Karl Kaufmann UK01
+    applicant_name: DE84508800500194785001Empfanger Karl Kaufmann UK01
     bank_reference: 0724710352952868
     compensation_amount: null
     currency: EUR
@@ -3506,8 +3472,7 @@ transactions:
       currency: EUR
     applicant_bin: DRESDEFF508
     applicant_creditor_id: null
-    applicant_iban: DE10508800500194787400
-    applicant_name: Empfaenger Marta Metzger
+    applicant_name: DE10508800500194787400Empfaenger Marta Metzger
     bank_reference: '0724710333343453'
     compensation_amount: null
     currency: EUR
@@ -3557,8 +3522,8 @@ transactions:
       currency: EUR
     applicant_bin: SOGEFRPPXXX
     applicant_creditor_id: null
-    applicant_iban: FR1420041010050500013M02606
-    applicant_name: Empfaenger 7 mit 70 Zeichen Empfaenger 7 mit 70 Zeiche
+    applicant_name: FR1420041010050500013M02606Empfaenger 7 mit 70 Zeichen Empfaenger
+      7 mit 70 Zeiche
     bank_reference: 0724710352982472
     compensation_amount: null
     currency: EUR
@@ -3608,7 +3573,6 @@ transactions:
       currency: EUR
     applicant_bin: null
     applicant_creditor_id: null
-    applicant_iban: null
     applicant_name: null
     bank_reference: D4AF9E363A92E76F
     compensation_amount: null
@@ -3660,8 +3624,7 @@ transactions:
       currency: EUR
     applicant_bin: SOGEFRPPXXX
     applicant_creditor_id: null
-    applicant_iban: FR1420041010050500013M02606
-    applicant_name: Empfaenger 1
+    applicant_name: FR1420041010050500013M02606Empfaenger 1
     bank_reference: '0724710333366624'
     compensation_amount: null
     currency: EUR
@@ -3711,12 +3674,11 @@ transactions:
       currency: EUR
     applicant_bin: DRESDEFF508
     applicant_creditor_id: null
-    applicant_iban: DE14508800500194785000
-    applicant_name: Karl Kaufmann
+    applicant_name: DE14508800500194785000Karl Kaufmann
     bank_reference: 0724710352952868
     compensation_amount: null
     currency: EUR
-    customer_reference: NONREF
+    customer_reference: null
     date: !!python/object/apply:mt940.models.Date
     - !!binary |
       B9cJBA==
@@ -3759,12 +3721,11 @@ transactions:
       currency: EUR
     applicant_bin: DRESDEFF508
     applicant_creditor_id: null
-    applicant_iban: DE14508800500194785000
-    applicant_name: Karl Kaufmann
+    applicant_name: DE14508800500194785000Karl Kaufmann
     bank_reference: 0724710324661086
     compensation_amount: null
     currency: EUR
-    customer_reference: NONREF
+    customer_reference: null
     date: !!python/object/apply:mt940.models.Date
     - !!binary |
       B9cJBA==
@@ -3807,12 +3768,11 @@ transactions:
       currency: EUR
     applicant_bin: DRESDEFF508
     applicant_creditor_id: null
-    applicant_iban: DE14508800500194785000
-    applicant_name: KARL        KAUFMANN
+    applicant_name: DE14508800500194785000KARL        KAUFMANN
     bank_reference: '0724710333360224'
     compensation_amount: null
     currency: EUR
-    customer_reference: NONREF
+    customer_reference: null
     date: !!python/object/apply:mt940.models.Date
     - !!binary |
       B9cJBA==
@@ -3855,12 +3815,11 @@ transactions:
       currency: EUR
     applicant_bin: DRESDEFF508
     applicant_creditor_id: null
-    applicant_iban: DE03508800500194791600
-    applicant_name: Quentin Quast
+    applicant_name: DE03508800500194791600Quentin Quast
     bank_reference: '0724710324647446'
     compensation_amount: null
     currency: EUR
-    customer_reference: NONREF
+    customer_reference: null
     date: !!python/object/apply:mt940.models.Date
     - !!binary |
       B9cJBA==
@@ -3903,12 +3862,11 @@ transactions:
       currency: EUR
     applicant_bin: DRESDEFF508
     applicant_creditor_id: null
-    applicant_iban: DE14508800500194785000
-    applicant_name: KARL        KAUFMANN
+    applicant_name: DE14508800500194785000KARL        KAUFMANN
     bank_reference: '0724710333343453'
     compensation_amount: null
     currency: EUR
-    customer_reference: NONREF
+    customer_reference: null
     date: !!python/object/apply:mt940.models.Date
     - !!binary |
       B9cJBw==
@@ -3951,12 +3909,11 @@ transactions:
       currency: EUR
     applicant_bin: DRESDEFF508
     applicant_creditor_id: null
-    applicant_iban: DE03508800500194791600
-    applicant_name: Quentin Quast
+    applicant_name: DE03508800500194791600Quentin Quast
     bank_reference: '0724710324647450'
     compensation_amount: null
     currency: EUR
-    customer_reference: NONREF
+    customer_reference: null
     date: !!python/object/apply:mt940.models.Date
     - !!binary |
       B9cJBw==
@@ -3999,12 +3956,11 @@ transactions:
       currency: EUR
     applicant_bin: DRESDEFF508
     applicant_creditor_id: null
-    applicant_iban: DE14508800500194785000
-    applicant_name: Karl Kaufmann
+    applicant_name: DE14508800500194785000Karl Kaufmann
     bank_reference: 0724710324661090
     compensation_amount: null
     currency: EUR
-    customer_reference: NONREF
+    customer_reference: null
     date: !!python/object/apply:mt940.models.Date
     - !!binary |
       B9cJBw==
@@ -4047,7 +4003,6 @@ transactions:
       currency: EUR
     applicant_bin: null
     applicant_creditor_id: null
-    applicant_iban: null
     applicant_name: null
     bank_reference: 536D80EFEC56ACF8
     compensation_amount: null
@@ -4098,12 +4053,11 @@ transactions:
       currency: EUR
     applicant_bin: null
     applicant_creditor_id: null
-    applicant_iban: null
     applicant_name: null
     bank_reference: '0724710345316116'
     compensation_amount: null
     currency: EUR
-    customer_reference: TFNr 40001 MSGID
+    customer_reference: null
     date: !!python/object/apply:mt940.models.Date
     - !!binary |
       B9cJBA==
@@ -4147,12 +4101,11 @@ transactions:
       currency: EUR
     applicant_bin: null
     applicant_creditor_id: null
-    applicant_iban: null
     applicant_name: null
     bank_reference: '0724710351063401'
     compensation_amount: null
     currency: EUR
-    customer_reference: TFNr 44001 MSGID
+    customer_reference: null
     date: !!python/object/apply:mt940.models.Date
     - !!binary |
       B9cJBA==
@@ -4196,12 +4149,11 @@ transactions:
       currency: EUR
     applicant_bin: null
     applicant_creditor_id: null
-    applicant_iban: null
     applicant_name: null
     bank_reference: '0724710345316110'
     compensation_amount: null
     currency: EUR
-    customer_reference: TFNr 40001 MSGID
+    customer_reference: null
     date: !!python/object/apply:mt940.models.Date
     - !!binary |
       B9cJBA==
@@ -4245,12 +4197,12 @@ transactions:
       currency: EUR
     applicant_bin: PBNKDEFF100
     applicant_creditor_id: null
-    applicant_iban: DE42100100100043921105
-    applicant_name: Richter Renate 70 Zeichen Beginn Fuellzeichen xxxxxxxx
+    applicant_name: DE42100100100043921105Richter Renate 70 Zeichen Beginn Fuellzeichen
+      xxxxxxxx
     bank_reference: 0724710290659857
     compensation_amount: null
     currency: EUR
-    customer_reference: NONREF
+    customer_reference: null
     date: !!python/object/apply:mt940.models.Date
     - !!binary |
       B9cJBA==
@@ -4294,12 +4246,12 @@ transactions:
       currency: EUR
     applicant_bin: PBNKDEFF100
     applicant_creditor_id: null
-    applicant_iban: DE42100100100043921105
-    applicant_name: Richter Renate 70 Zeichen Beginn Fuellzeichen xxxxxxxx
+    applicant_name: DE42100100100043921105Richter Renate 70 Zeichen Beginn Fuellzeichen
+      xxxxxxxx
     bank_reference: 0724710290624796
     compensation_amount: null
     currency: EUR
-    customer_reference: NONREF
+    customer_reference: null
     date: !!python/object/apply:mt940.models.Date
     - !!binary |
       B9cJBA==
@@ -4342,12 +4294,11 @@ transactions:
       currency: EUR
     applicant_bin: null
     applicant_creditor_id: null
-    applicant_iban: null
     applicant_name: null
     bank_reference: R724710351063405
     compensation_amount: null
     currency: EUR
-    customer_reference: TFNr 44001 MSGID
+    customer_reference: null
     date: !!python/object/apply:mt940.models.Date
     - !!binary |
       B9cJBA==
@@ -4387,7 +4338,6 @@ transactions:
       - '-3572569.03'
       currency: EUR
     applicant_bin: null
-    applicant_iban: null
     applicant_name: null
     bank_reference: null
     currency: EUR
@@ -4423,12 +4373,11 @@ transactions:
       currency: EUR
     applicant_bin: DRESDEFF508
     applicant_creditor_id: null
-    applicant_iban: DE03508800500194791600
-    applicant_name: QUENTIN        QUAST
+    applicant_name: DE03508800500194791600QUENTIN        QUAST
     bank_reference: 0724710333345079
     compensation_amount: null
     currency: EUR
-    customer_reference: NONREF
+    customer_reference: null
     date: !!python/object/apply:mt940.models.Date
     - !!binary |
       B9cJBA==
@@ -4471,12 +4420,11 @@ transactions:
       currency: EUR
     applicant_bin: DRESDEFF508
     applicant_creditor_id: null
-    applicant_iban: DE03508800500194791600
-    applicant_name: Quentin Quast
+    applicant_name: DE03508800500194791600Quentin Quast
     bank_reference: 0724710352956584
     compensation_amount: null
     currency: EUR
-    customer_reference: NONREF
+    customer_reference: null
     date: !!python/object/apply:mt940.models.Date
     - !!binary |
       B9cJBA==
@@ -4519,7 +4467,6 @@ transactions:
       currency: EUR
     applicant_bin: null
     applicant_creditor_id: null
-    applicant_iban: null
     applicant_name: null
     bank_reference: F2CA963F5C750549
     compensation_amount: null
@@ -4570,7 +4517,6 @@ transactions:
       currency: EUR
     applicant_bin: null
     applicant_creditor_id: null
-    applicant_iban: null
     applicant_name: null
     bank_reference: FFCD94B7601B6E06
     compensation_amount: null
@@ -4621,7 +4567,6 @@ transactions:
       currency: EUR
     applicant_bin: null
     applicant_creditor_id: null
-    applicant_iban: null
     applicant_name: null
     bank_reference: DED4A9D0CA11033B
     compensation_amount: null
@@ -4672,12 +4617,12 @@ transactions:
       currency: EUR
     applicant_bin: DRESDEFF508
     applicant_creditor_id: null
-    applicant_iban: DE51508800500190038900
-    applicant_name: Richter Renate 70 Zeichen Beginn Fuellzeichen xxxxxxxx
+    applicant_name: DE51508800500190038900Richter Renate 70 Zeichen Beginn Fuellzeichen
+      xxxxxxxx
     bank_reference: 0724710290648274
     compensation_amount: null
     currency: EUR
-    customer_reference: NONREF
+    customer_reference: null
     date: !!python/object/apply:mt940.models.Date
     - !!binary |
       B9cJBA==

--- a/mt940_tests/betterplace/sepa_snippet.all.yml
+++ b/mt940_tests/betterplace/sepa_snippet.all.yml
@@ -1,0 +1,650 @@
+&id004 !!python/object:mt940.models.Transactions
+data:
+  account_identification: 50880050/0194791600888
+  available_balance: !!python/object:mt940.models.Balance
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '-4472049.09'
+      currency: EUR
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    status: D
+  final_closing_balance: !!python/object:mt940.models.Balance
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '-4472049.09'
+      currency: EUR
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    status: D
+  final_opening_balance: !!python/object:mt940.models.Balance
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '-1970431.87'
+      currency: EUR
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJAw==
+    status: D
+  sequence_number: '00001'
+  statement_number: '00004'
+  transaction_reference: T089414096000001
+options: !!python/object/new:mt940.options.Options
+  state:
+  - true
+  - true
+  - true
+  - true
+  - true
+  - true
+  - true
+  - true
+  - true
+  - true
+tags:
+  13: !!python/object:mt940.tags.DateTimeIndication
+    re: !!python/object/apply:re._compile
+    - "^\n    (?P<year>\\d{2})\n    (?P<month>\\d{2})\n    (?P<day>\\d{2})\n    (?P<hour>\\\
+      d{2})\n    (?P<minute>\\d{2})\n    ((?P<offset_sign>[+-])(?P<offset>\\d{4}))?\n\
+      \    "
+    - 98
+  20: !!python/object:mt940.tags.TransactionReferenceNumber
+    re: !!python/object/apply:re._compile
+    - (?P<transaction_reference>.{0,16})
+    - 98
+  21: !!python/object:mt940.tags.RelatedReference
+    re: !!python/object/apply:re._compile
+    - (?P<related_reference>.{0,16})
+    - 98
+  25: !!python/object:mt940.tags.AccountIdentification
+    re: !!python/object/apply:re._compile
+    - (?P<account_identification>.{0,35})
+    - 98
+  28: !!python/object:mt940.tags.StatementNumber
+    re: !!python/object/apply:re._compile
+    - "\n    (?P<statement_number>\\d{1,5})  # 5n\n    (?:/?(?P<sequence_number>\\\
+      d{1,5}))?  # [/5n]\n    $"
+    - 98
+  60: !!python/object:mt940.tags.OpeningBalance
+    re: &id001 !!python/object/apply:re._compile
+    - "^\n    (?P<status>[DC])  # 1!a Debit/Credit\n    (?P<year>\\d{2})  # 6!n Value\
+      \ Date (YYMMDD)\n    (?P<month>\\d{2})\n    (?P<day>\\d{2})\n    (?P<currency>.{3})\
+      \  # 3!a Currency\n    (?P<amount>[0-9,]{0,16})  # 15d Amount (includes decimal\
+      \ sign, so 16)\n    "
+    - 98
+  60M: !!python/object:mt940.tags.IntermediateOpeningBalance
+    re: *id001
+  60F: !!python/object:mt940.tags.FinalOpeningBalance
+    re: *id001
+  61: !!python/object:mt940.tags.Statement
+    re: !!python/object/apply:re._compile
+    - "^\n    (?P<year>\\d{2})  # 6!n Value Date (YYMMDD)\n    (?P<month>\\d{2})\n\
+      \    (?P<day>\\d{2})\n    (?P<entry_month>\\d{2}|\\s{2})?  # [4!n] Entry Date\
+      \ (MMDD)\n    (?P<entry_day>\\d{2}|\\s{2})?\n    (?P<status>R?[DC])  # 2a Debit/Credit\
+      \ Mark\n    (?P<funds_code>[A-Z])? # [1!a] Funds Code (3rd character of the\
+      \ currency\n                            # code, if needed)\n    [\\n ]?\n  \
+      \  (?P<amount>[\\d,]{1,15})  # 15d Amount\n    (?P<id>[A-Z][A-Z0-9 ]{3})?\n\
+      \    (?P<customer_reference>((?!//)[^\\n]){0,16})\n    (//(?P<bank_reference>.{0,23}))?\n\
+      \    # Supplementary details: the SWIFT spec caps this at 34x, but some banks\n\
+      \    # (e.g. Wise, issue #117) send more, so the length limit is relaxed. This\n\
+      \    # only ever turns a previous parse error into a successful parse.\n   \
+      \ (\\n?(?P<extra_details>.*))?\n    $"
+    - 98
+  62: !!python/object:mt940.tags.ClosingBalance
+    re: *id001
+  62M: !!python/object:mt940.tags.IntermediateClosingBalance
+    re: *id001
+  62F: !!python/object:mt940.tags.FinalClosingBalance
+    re: *id001
+  64: !!python/object:mt940.tags.AvailableBalance
+    re: *id001
+  65: !!python/object:mt940.tags.ForwardAvailableBalance
+    re: *id001
+  86: !!python/object:mt940.tags.TransactionDetails
+    re: !!python/object/apply:re._compile
+    - "\n    (?P<transaction_details>[\\s\\S]*)\n    "
+    - 98
+  34: !!python/object:mt940.tags.FloorLimitIndicator
+    re: !!python/object/apply:re._compile
+    - "^\n    (?P<currency>[A-Z]{3})  # 3!a Currency\n    (?P<status>[DC ]?)  # 2a\
+      \ Debit/Credit Mark\n    (?P<amount>[0-9,]{0,16})  # 15d Amount (includes decimal\
+      \ sign, so 16)\n    $"
+    - 98
+  NS: !!python/object:mt940.tags.NonSwift
+    re: !!python/object/apply:re._compile
+    - "\n    (?P<non_swift>[\\s\\S]*)\n    $"
+    - 98
+  90: !!python/object:mt940.tags.SumEntries
+    re: &id002 !!python/object/apply:re._compile
+    - "^\n    (?P<number>\\d*)\n    (?P<currency>.{3})  # 3!a Currency\n    (?P<amount>[\\\
+      d,]{1,15})  # 15d Amount\n    "
+    - 98
+  90D: !!python/object:mt940.tags.SumDebitEntries
+    re: *id002
+  90C: !!python/object:mt940.tags.SumCreditEntries
+    re: *id002
+transaction_boundary: !!python/object/apply:builtins.frozenset
+- []
+transactions:
+- !!python/object:mt940.models.Transaction
+  data:
+    FRST_ONE_OFF_RECC: null
+    additional_position_date: null
+    additional_position_reference: null
+    additional_purpose: null
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '50990.05'
+      currency: EUR
+    applicant_bin: DRESDEFF508
+    applicant_creditor_id: null
+    applicant_iban: DE14508800500194785000
+    applicant_name: KARL        KAUFMANN
+    bank_reference: '0724710333343453'
+    compensation_amount: null
+    currency: EUR
+    customer_reference: NONREF
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBw==
+    debitor_identifier: null
+    deviate_applicant: null
+    deviate_recipient: null
+    end_to_end_reference: EndToEndId TFNR 22 004 00001
+    entry_date: &id003 !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    extra_details: ''
+    funds_code: R
+    guessed_entry_date: *id003
+    gvc_applicant_bin: null
+    gvc_applicant_iban: null
+    id: NTRF
+    old_SEPA_CI: null
+    old_SEPA_additional_position_reference: null
+    original_amount: null
+    posting_text: GUTSCHRIFT
+    prima_nota: 0399
+    purpose: Verw CTSc-01 BC-PPP TFNr 22 004
+    purpose_code: null
+    recipient_name: null
+    return_debit_notes: null
+    settlement_tag: null
+    status: C
+    transaction_code: '166'
+    transaction_reference: T089414086000001
+  transactions: *id004
+- !!python/object:mt940.models.Transaction
+  data:
+    FRST_ONE_OFF_RECC: null
+    additional_position_date: null
+    additional_position_reference: null
+    additional_purpose: null
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '154551.93'
+      currency: EUR
+    applicant_bin: DRESDEFF508
+    applicant_creditor_id: null
+    applicant_iban: DE03508800500194791600
+    applicant_name: Quentin Quast
+    bank_reference: '0724710324647450'
+    compensation_amount: null
+    currency: EUR
+    customer_reference: NONREF
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBw==
+    debitor_identifier: null
+    deviate_applicant: null
+    deviate_recipient: null
+    end_to_end_reference: TFNR 0300300004
+    entry_date: &id005 !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    extra_details: ''
+    funds_code: R
+    guessed_entry_date: *id005
+    gvc_applicant_bin: null
+    gvc_applicant_iban: null
+    id: NTRF
+    old_SEPA_CI: null
+    old_SEPA_additional_position_reference: null
+    original_amount: null
+    posting_text: GUTSCHRIFT
+    prima_nota: 0399
+    purpose: Strukturierter Verwendungszweck 30030004 DE
+    purpose_code: null
+    recipient_name: null
+    return_debit_notes: null
+    settlement_tag: null
+    status: C
+    transaction_code: '166'
+    transaction_reference: T089414086000001
+  transactions: *id004
+- !!python/object:mt940.models.Transaction
+  data:
+    FRST_ONE_OFF_RECC: null
+    additional_position_date: null
+    additional_position_reference: null
+    additional_purpose: null
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '154551.93'
+      currency: EUR
+    applicant_bin: DRESDEFF508
+    applicant_creditor_id: null
+    applicant_iban: DE14508800500194785000
+    applicant_name: Karl Kaufmann
+    bank_reference: 0724710324661090
+    compensation_amount: null
+    currency: EUR
+    customer_reference: NONREF
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBw==
+    debitor_identifier: null
+    deviate_applicant: null
+    deviate_recipient: null
+    end_to_end_reference: TFNR 0500500004
+    entry_date: &id006 !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    extra_details: ''
+    funds_code: R
+    guessed_entry_date: *id006
+    gvc_applicant_bin: null
+    gvc_applicant_iban: null
+    id: NTRF
+    old_SEPA_CI: null
+    old_SEPA_additional_position_reference: null
+    original_amount: null
+    posting_text: GUTSCHRIFT
+    prima_nota: 0399
+    purpose: Strukturierter Verwendungszweck 50050004 DE
+    purpose_code: null
+    recipient_name: null
+    return_debit_notes: null
+    settlement_tag: null
+    status: C
+    transaction_code: '166'
+    transaction_reference: T089414086000001
+  transactions: *id004
+- !!python/object:mt940.models.Transaction
+  data:
+    FRST_ONE_OFF_RECC: null
+    additional_position_date: null
+    additional_position_reference: null
+    additional_purpose: null
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '-1500.00'
+      currency: EUR
+    applicant_bin: null
+    applicant_creditor_id: null
+    applicant_iban: null
+    applicant_name: null
+    bank_reference: 536D80EFEC56ACF8
+    compensation_amount: null
+    currency: EUR
+    customer_reference: 'KREF+
+
+      TFNr 01022 MSGID CTSc-01 EBBMTLG:SEPA-Ueberweisungsauftrag Datei mit 0000001
+      Zahlungen'
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    debitor_identifier: null
+    deviate_applicant: null
+    deviate_recipient: null
+    end_to_end_reference: null
+    entry_date: &id007 !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    extra_details: ''
+    funds_code: R
+    guessed_entry_date: *id007
+    gvc_applicant_bin: null
+    gvc_applicant_iban: null
+    id: NTRF
+    old_SEPA_CI: null
+    old_SEPA_additional_position_reference: null
+    original_amount: null
+    posting_text: SEPA-UEBERW
+    prima_nota: 0399
+    purpose: null
+    purpose_code: null
+    recipient_name: null
+    return_debit_notes: null
+    settlement_tag: null
+    status: D
+    transaction_code: '191'
+    transaction_reference: T089414086000001
+  transactions: *id004
+- !!python/object:mt940.models.Transaction
+  data:
+    FRST_ONE_OFF_RECC: null
+    additional_position_date: null
+    additional_position_reference: null
+    additional_purpose: null
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '-0.08'
+      currency: EUR
+    applicant_bin: null
+    applicant_creditor_id: null
+    applicant_iban: null
+    applicant_name: null
+    bank_reference: '0724710345316116'
+    compensation_amount: null
+    currency: EUR
+    customer_reference: TFNr 40001 MSGID
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    debitor_identifier: null
+    deviate_applicant: null
+    deviate_recipient: null
+    end_to_end_reference: TFNR 40001 00005MTLG:Grund nicht spezifiziert Reject aus
+      SEPA-Ueberweisungsauftrag
+    entry_date: &id008 !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    extra_details: ''
+    funds_code: R
+    guessed_entry_date: *id008
+    gvc_applicant_bin: null
+    gvc_applicant_iban: null
+    id: NTRF
+    old_SEPA_CI: null
+    old_SEPA_additional_position_reference: null
+    original_amount: null
+    posting_text: RETOURE
+    prima_nota: 0399
+    purpose: null
+    purpose_code: null
+    recipient_name: null
+    return_debit_notes: '914'
+    settlement_tag: null
+    status: D
+    transaction_code: '159'
+    transaction_reference: T089414096000001
+  transactions: *id004
+- !!python/object:mt940.models.Transaction
+  data:
+    FRST_ONE_OFF_RECC: null
+    additional_position_date: null
+    additional_position_reference: null
+    additional_purpose: null
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '335.33'
+      currency: EUR
+    applicant_bin: null
+    applicant_creditor_id: null
+    applicant_iban: null
+    applicant_name: null
+    bank_reference: '0724710351063401'
+    compensation_amount: null
+    currency: EUR
+    customer_reference: TFNr 44001 MSGID
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    debitor_identifier: null
+    deviate_applicant: null
+    deviate_recipient: null
+    end_to_end_reference: TFNR 44001 00001MTLG:Grund nicht spezifiziert Reject aus
+      SEPA-Ueberweisungsauftrag
+    entry_date: &id009 !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    extra_details: ''
+    funds_code: R
+    guessed_entry_date: *id009
+    gvc_applicant_bin: null
+    gvc_applicant_iban: null
+    id: NTRF
+    old_SEPA_CI: null
+    old_SEPA_additional_position_reference: null
+    original_amount: null
+    posting_text: RETOURE
+    prima_nota: 0399
+    purpose: null
+    purpose_code: null
+    recipient_name: null
+    return_debit_notes: '914'
+    settlement_tag: null
+    status: C
+    transaction_code: '159'
+    transaction_reference: T089414096000001
+  transactions: *id004
+- !!python/object:mt940.models.Transaction
+  data:
+    FRST_ONE_OFF_RECC: null
+    additional_position_date: null
+    additional_position_reference: null
+    additional_purpose: null
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '15000'
+      currency: EUR
+    applicant_bin: null
+    applicant_creditor_id: null
+    applicant_iban: null
+    applicant_name: null
+    bank_reference: '0724710345316110'
+    compensation_amount: null
+    currency: EUR
+    customer_reference: TFNr 40001 MSGID
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    debitor_identifier: null
+    deviate_applicant: null
+    deviate_recipient: null
+    end_to_end_reference: TFNR 40001 00002MTLG:Grund nicht spezifiziert Reject aus
+      SEPA-Ueberweisungsauftrag
+    entry_date: &id010 !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    extra_details: ''
+    funds_code: R
+    guessed_entry_date: *id010
+    gvc_applicant_bin: null
+    gvc_applicant_iban: null
+    id: NTRF
+    old_SEPA_CI: null
+    old_SEPA_additional_position_reference: null
+    original_amount: null
+    posting_text: RETOURE
+    prima_nota: 0399
+    purpose: null
+    purpose_code: null
+    recipient_name: null
+    return_debit_notes: '914'
+    settlement_tag: null
+    status: C
+    transaction_code: '159'
+    transaction_reference: T089414096000001
+  transactions: *id004
+- !!python/object:mt940.models.Transaction
+  data:
+    FRST_ONE_OFF_RECC: null
+    additional_position_date: null
+    additional_position_reference: null
+    additional_purpose: null
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '15000.05'
+      currency: EUR
+    applicant_bin: PBNKDEFF100
+    applicant_creditor_id: null
+    applicant_iban: DE42100100100043921105
+    applicant_name: Richter Renate 70 Zeichen Beginn Fuellzeichen xxxxxxxx
+    bank_reference: 0724710290659857
+    compensation_amount: null
+    currency: EUR
+    customer_reference: NONREF
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    debitor_identifier: null
+    deviate_applicant: null
+    deviate_recipient: null
+    end_to_end_reference: EndToEndIdTFNR2000100001
+    entry_date: &id011 !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    extra_details: ''
+    funds_code: R
+    guessed_entry_date: *id011
+    gvc_applicant_bin: null
+    gvc_applicant_iban: null
+    id: NTRF
+    old_SEPA_CI: null
+    old_SEPA_additional_position_reference: null
+    original_amount: null
+    posting_text: GUTSCHRIFT
+    prima_nota: 0399
+    purpose: TO 13 TFNr 20001 Eingangskanal Mint Unstrukturierter Verwendungszweck
+      140 Zeichen Beginn Fuellzeichen xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+    purpose_code: null
+    recipient_name: null
+    return_debit_notes: null
+    settlement_tag: null
+    status: C
+    transaction_code: '166'
+    transaction_reference: T089414096000001
+  transactions: *id004
+- !!python/object:mt940.models.Transaction
+  data:
+    FRST_ONE_OFF_RECC: null
+    additional_position_date: null
+    additional_position_reference: null
+    additional_purpose: null
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '125004.88'
+      currency: EUR
+    applicant_bin: PBNKDEFF100
+    applicant_creditor_id: null
+    applicant_iban: DE42100100100043921105
+    applicant_name: Richter Renate 70 Zeichen Beginn Fuellzeichen xxxxxxxx
+    bank_reference: 0724710290624796
+    compensation_amount: null
+    currency: EUR
+    customer_reference: NONREF
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    debitor_identifier: null
+    deviate_applicant: null
+    deviate_recipient: null
+    end_to_end_reference: null
+    entry_date: &id012 !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    extra_details: ''
+    funds_code: R
+    guessed_entry_date: *id012
+    gvc_applicant_bin: null
+    gvc_applicant_iban: null
+    id: NTRF
+    old_SEPA_CI: null
+    old_SEPA_additional_position_reference: null
+    original_amount: null
+    posting_text: GUTSCHRIFT
+    prima_nota: 0399
+    purpose: TO13 TF20005 MINT
+    purpose_code: null
+    recipient_name: null
+    return_debit_notes: null
+    settlement_tag: null
+    status: C
+    transaction_code: '166'
+    transaction_reference: T089414096000001
+  transactions: *id004
+- !!python/object:mt940.models.Transaction
+  data:
+    FRST_ONE_OFF_RECC: null
+    additional_position_date: null
+    additional_position_reference: null
+    additional_purpose: null
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '915311.55'
+      currency: EUR
+    applicant_bin: null
+    applicant_creditor_id: null
+    applicant_iban: null
+    applicant_name: null
+    bank_reference: R724710351063405
+    compensation_amount: null
+    currency: EUR
+    customer_reference: TFNr 44001 MSGID
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    debitor_identifier: null
+    deviate_applicant: null
+    deviate_recipient: null
+    end_to_end_reference: TFNR 44001 00002MTLG:IBAN ungueltig Rueckueberweisung aus
+      SEPA-Ueberweisungsauftrag
+    entry_date: &id013 !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    extra_details: ''
+    funds_code: R
+    guessed_entry_date: *id013
+    gvc_applicant_bin: null
+    gvc_applicant_iban: null
+    id: NTRF
+    old_SEPA_CI: null
+    old_SEPA_additional_position_reference: null
+    original_amount: null
+    posting_text: RETOURE
+    prima_nota: 0399
+    purpose: null
+    purpose_code: null
+    recipient_name: null
+    return_debit_notes: '901'
+    settlement_tag: null
+    status: C
+    transaction_code: '159'
+    transaction_reference: T089414096000001
+  transactions: *id004
+- !!python/object:mt940.models.Transaction
+  data:
+    additional_purpose: null
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '-3572569.03'
+      currency: EUR
+    applicant_bin: null
+    applicant_iban: null
+    applicant_name: null
+    bank_reference: null
+    currency: EUR
+    customer_reference: NONREF
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    entry_date: &id014 !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9cJBA==
+    extra_details: ''
+    funds_code: R
+    guessed_entry_date: *id014
+    id: NMSC
+    posting_text: SAMMLER
+    prima_nota: '9800'
+    purpose: 0904059001
+    recipient_name: null
+    return_debit_notes: null
+    status: D
+    transaction_code: 079
+    transaction_reference: T089414096000001
+  transactions: *id004

--- a/mt940_tests/betterplace/sepa_snippet.yml
+++ b/mt940_tests/betterplace/sepa_snippet.yml
@@ -31,6 +31,18 @@ data:
   sequence_number: '00001'
   statement_number: '00004'
   transaction_reference: T089414096000001
+options: !!python/object/new:mt940.options.Options
+  state:
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
 tags:
   13: !!python/object:mt940.tags.DateTimeIndication
     re: !!python/object/apply:re._compile
@@ -128,12 +140,11 @@ transactions:
       currency: EUR
     applicant_bin: DRESDEFF508
     applicant_creditor_id: null
-    applicant_iban: DE14508800500194785000
-    applicant_name: KARL        KAUFMANN
+    applicant_name: DE14508800500194785000KARL        KAUFMANN
     bank_reference: '0724710333343453'
     compensation_amount: null
     currency: EUR
-    customer_reference: NONREF
+    customer_reference: null
     date: !!python/object/apply:mt940.models.Date
     - !!binary |
       B9cJBw==
@@ -176,12 +187,11 @@ transactions:
       currency: EUR
     applicant_bin: DRESDEFF508
     applicant_creditor_id: null
-    applicant_iban: DE03508800500194791600
-    applicant_name: Quentin Quast
+    applicant_name: DE03508800500194791600Quentin Quast
     bank_reference: '0724710324647450'
     compensation_amount: null
     currency: EUR
-    customer_reference: NONREF
+    customer_reference: null
     date: !!python/object/apply:mt940.models.Date
     - !!binary |
       B9cJBw==
@@ -224,12 +234,11 @@ transactions:
       currency: EUR
     applicant_bin: DRESDEFF508
     applicant_creditor_id: null
-    applicant_iban: DE14508800500194785000
-    applicant_name: Karl Kaufmann
+    applicant_name: DE14508800500194785000Karl Kaufmann
     bank_reference: 0724710324661090
     compensation_amount: null
     currency: EUR
-    customer_reference: NONREF
+    customer_reference: null
     date: !!python/object/apply:mt940.models.Date
     - !!binary |
       B9cJBw==
@@ -272,7 +281,6 @@ transactions:
       currency: EUR
     applicant_bin: null
     applicant_creditor_id: null
-    applicant_iban: null
     applicant_name: null
     bank_reference: 536D80EFEC56ACF8
     compensation_amount: null
@@ -323,12 +331,11 @@ transactions:
       currency: EUR
     applicant_bin: null
     applicant_creditor_id: null
-    applicant_iban: null
     applicant_name: null
     bank_reference: '0724710345316116'
     compensation_amount: null
     currency: EUR
-    customer_reference: TFNr 40001 MSGID
+    customer_reference: null
     date: !!python/object/apply:mt940.models.Date
     - !!binary |
       B9cJBA==
@@ -372,12 +379,11 @@ transactions:
       currency: EUR
     applicant_bin: null
     applicant_creditor_id: null
-    applicant_iban: null
     applicant_name: null
     bank_reference: '0724710351063401'
     compensation_amount: null
     currency: EUR
-    customer_reference: TFNr 44001 MSGID
+    customer_reference: null
     date: !!python/object/apply:mt940.models.Date
     - !!binary |
       B9cJBA==
@@ -421,12 +427,11 @@ transactions:
       currency: EUR
     applicant_bin: null
     applicant_creditor_id: null
-    applicant_iban: null
     applicant_name: null
     bank_reference: '0724710345316110'
     compensation_amount: null
     currency: EUR
-    customer_reference: TFNr 40001 MSGID
+    customer_reference: null
     date: !!python/object/apply:mt940.models.Date
     - !!binary |
       B9cJBA==
@@ -470,12 +475,12 @@ transactions:
       currency: EUR
     applicant_bin: PBNKDEFF100
     applicant_creditor_id: null
-    applicant_iban: DE42100100100043921105
-    applicant_name: Richter Renate 70 Zeichen Beginn Fuellzeichen xxxxxxxx
+    applicant_name: DE42100100100043921105Richter Renate 70 Zeichen Beginn Fuellzeichen
+      xxxxxxxx
     bank_reference: 0724710290659857
     compensation_amount: null
     currency: EUR
-    customer_reference: NONREF
+    customer_reference: null
     date: !!python/object/apply:mt940.models.Date
     - !!binary |
       B9cJBA==
@@ -519,12 +524,12 @@ transactions:
       currency: EUR
     applicant_bin: PBNKDEFF100
     applicant_creditor_id: null
-    applicant_iban: DE42100100100043921105
-    applicant_name: Richter Renate 70 Zeichen Beginn Fuellzeichen xxxxxxxx
+    applicant_name: DE42100100100043921105Richter Renate 70 Zeichen Beginn Fuellzeichen
+      xxxxxxxx
     bank_reference: 0724710290624796
     compensation_amount: null
     currency: EUR
-    customer_reference: NONREF
+    customer_reference: null
     date: !!python/object/apply:mt940.models.Date
     - !!binary |
       B9cJBA==
@@ -567,12 +572,11 @@ transactions:
       currency: EUR
     applicant_bin: null
     applicant_creditor_id: null
-    applicant_iban: null
     applicant_name: null
     bank_reference: R724710351063405
     compensation_amount: null
     currency: EUR
-    customer_reference: TFNr 44001 MSGID
+    customer_reference: null
     date: !!python/object/apply:mt940.models.Date
     - !!binary |
       B9cJBA==
@@ -612,7 +616,6 @@ transactions:
       - '-3572569.03'
       currency: EUR
     applicant_bin: null
-    applicant_iban: null
     applicant_name: null
     bank_reference: null
     currency: EUR

--- a/mt940_tests/betterplace/sepa_snippet_broken.yml
+++ b/mt940_tests/betterplace/sepa_snippet_broken.yml
@@ -31,6 +31,18 @@ data:
   sequence_number: '00001'
   statement_number: '00004'
   transaction_reference: T089414086000001
+options: !!python/object/new:mt940.options.Options
+  state:
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
 tags:
   13: !!python/object:mt940.tags.DateTimeIndication
     re: !!python/object/apply:re._compile

--- a/mt940_tests/betterplace/with_binary_character.all.yml
+++ b/mt940_tests/betterplace/with_binary_character.all.yml
@@ -1,0 +1,251 @@
+&id004 !!python/object:mt940.models.Transactions
+data:
+  account_identification: 51230800/0000007304
+  final_closing_balance: !!python/object:mt940.models.Balance
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '131193.19'
+      currency: EUR
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9oDEw==
+    status: C
+  final_opening_balance: !!python/object:mt940.models.Balance
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '130073.19'
+      currency: EUR
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9oDEg==
+    status: C
+  sequence_number: '00001'
+  statement_number: '00053'
+  transaction_reference: "STAR1\xDCTUMS"
+options: !!python/object/new:mt940.options.Options
+  state:
+  - true
+  - true
+  - true
+  - true
+  - true
+  - true
+  - true
+  - true
+  - true
+  - true
+tags:
+  13: !!python/object:mt940.tags.DateTimeIndication
+    re: !!python/object/apply:re._compile
+    - "^\n    (?P<year>\\d{2})\n    (?P<month>\\d{2})\n    (?P<day>\\d{2})\n    (?P<hour>\\\
+      d{2})\n    (?P<minute>\\d{2})\n    ((?P<offset_sign>[+-])(?P<offset>\\d{4}))?\n\
+      \    "
+    - 98
+  20: !!python/object:mt940.tags.TransactionReferenceNumber
+    re: !!python/object/apply:re._compile
+    - (?P<transaction_reference>.{0,16})
+    - 98
+  21: !!python/object:mt940.tags.RelatedReference
+    re: !!python/object/apply:re._compile
+    - (?P<related_reference>.{0,16})
+    - 98
+  25: !!python/object:mt940.tags.AccountIdentification
+    re: !!python/object/apply:re._compile
+    - (?P<account_identification>.{0,35})
+    - 98
+  28: !!python/object:mt940.tags.StatementNumber
+    re: !!python/object/apply:re._compile
+    - "\n    (?P<statement_number>\\d{1,5})  # 5n\n    (?:/?(?P<sequence_number>\\\
+      d{1,5}))?  # [/5n]\n    $"
+    - 98
+  60: !!python/object:mt940.tags.OpeningBalance
+    re: &id001 !!python/object/apply:re._compile
+    - "^\n    (?P<status>[DC])  # 1!a Debit/Credit\n    (?P<year>\\d{2})  # 6!n Value\
+      \ Date (YYMMDD)\n    (?P<month>\\d{2})\n    (?P<day>\\d{2})\n    (?P<currency>.{3})\
+      \  # 3!a Currency\n    (?P<amount>[0-9,]{0,16})  # 15d Amount (includes decimal\
+      \ sign, so 16)\n    "
+    - 98
+  60M: !!python/object:mt940.tags.IntermediateOpeningBalance
+    re: *id001
+  60F: !!python/object:mt940.tags.FinalOpeningBalance
+    re: *id001
+  61: !!python/object:mt940.tags.Statement
+    re: !!python/object/apply:re._compile
+    - "^\n    (?P<year>\\d{2})  # 6!n Value Date (YYMMDD)\n    (?P<month>\\d{2})\n\
+      \    (?P<day>\\d{2})\n    (?P<entry_month>\\d{2}|\\s{2})?  # [4!n] Entry Date\
+      \ (MMDD)\n    (?P<entry_day>\\d{2}|\\s{2})?\n    (?P<status>R?[DC])  # 2a Debit/Credit\
+      \ Mark\n    (?P<funds_code>[A-Z])? # [1!a] Funds Code (3rd character of the\
+      \ currency\n                            # code, if needed)\n    [\\n ]?\n  \
+      \  (?P<amount>[\\d,]{1,15})  # 15d Amount\n    (?P<id>[A-Z][A-Z0-9 ]{3})?\n\
+      \    (?P<customer_reference>((?!//)[^\\n]){0,16})\n    (//(?P<bank_reference>.{0,23}))?\n\
+      \    # Supplementary details: the SWIFT spec caps this at 34x, but some banks\n\
+      \    # (e.g. Wise, issue #117) send more, so the length limit is relaxed. This\n\
+      \    # only ever turns a previous parse error into a successful parse.\n   \
+      \ (\\n?(?P<extra_details>.*))?\n    $"
+    - 98
+  62: !!python/object:mt940.tags.ClosingBalance
+    re: *id001
+  62M: !!python/object:mt940.tags.IntermediateClosingBalance
+    re: *id001
+  62F: !!python/object:mt940.tags.FinalClosingBalance
+    re: *id001
+  64: !!python/object:mt940.tags.AvailableBalance
+    re: *id001
+  65: !!python/object:mt940.tags.ForwardAvailableBalance
+    re: *id001
+  86: !!python/object:mt940.tags.TransactionDetails
+    re: !!python/object/apply:re._compile
+    - "\n    (?P<transaction_details>[\\s\\S]*)\n    "
+    - 98
+  34: !!python/object:mt940.tags.FloorLimitIndicator
+    re: !!python/object/apply:re._compile
+    - "^\n    (?P<currency>[A-Z]{3})  # 3!a Currency\n    (?P<status>[DC ]?)  # 2a\
+      \ Debit/Credit Mark\n    (?P<amount>[0-9,]{0,16})  # 15d Amount (includes decimal\
+      \ sign, so 16)\n    $"
+    - 98
+  NS: !!python/object:mt940.tags.NonSwift
+    re: !!python/object/apply:re._compile
+    - "\n    (?P<non_swift>[\\s\\S]*)\n    $"
+    - 98
+  90: !!python/object:mt940.tags.SumEntries
+    re: &id002 !!python/object/apply:re._compile
+    - "^\n    (?P<number>\\d*)\n    (?P<currency>.{3})  # 3!a Currency\n    (?P<amount>[\\\
+      d,]{1,15})  # 15d Amount\n    "
+    - 98
+  90D: !!python/object:mt940.tags.SumDebitEntries
+    re: *id002
+  90C: !!python/object:mt940.tags.SumCreditEntries
+    re: *id002
+transaction_boundary: !!python/object/apply:builtins.frozenset
+- []
+transactions:
+- !!python/object:mt940.models.Transaction
+  data:
+    additional_purpose: null
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '27.00'
+      currency: EUR
+    applicant_bin: '50070010'
+    applicant_iban: '0175526300'
+    applicant_name: PAYPAL
+    bank_reference: 32-P1-TCS49518
+    currency: EUR
+    customer_reference: 100323-03-100323
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9oDEw==
+    entry_date: &id003 !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9oDEw==
+    extra_details: ''
+    funds_code: R
+    guessed_entry_date: *id003
+    id: NTRF
+    posting_text: Bank Transfer Credit
+    prima_nota: '930226'
+    purpose: QQW53T2245ZGY46J ABBUCHUNGVOM PAYPAL-KONTO100318P3TX1433EV
+    recipient_name: null
+    return_debit_notes: '000'
+    status: C
+    transaction_code: '051'
+    transaction_reference: "STAR1\xDCT\xDFUMS"
+  transactions: *id004
+- !!python/object:mt940.models.Transaction
+  data:
+    additional_purpose: null
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '13068.30'
+      currency: EUR
+    applicant_bin: '51230800'
+    applicant_iban: '9990437808'
+    applicant_name: WIRECARD BANK AG
+    bank_reference: null
+    currency: EUR
+    customer_reference: NONREF
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9oDEw==
+    entry_date: &id005 !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9oDEw==
+    extra_details: ''
+    funds_code: R
+    guessed_entry_date: *id005
+    id: N051
+    posting_text: Bank Transfer Credit
+    prima_nota: '991118'
+    purpose: BETTERPLACE WDB E08.03.10-14.03.10
+    recipient_name: null
+    return_debit_notes: '000'
+    status: C
+    transaction_code: '051'
+    transaction_reference: "STAR1\xDCT\xDFUMS"
+  transactions: *id004
+- !!python/object:mt940.models.Transaction
+  data:
+    additional_purpose: null
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '-193282.05'
+      currency: EUR
+    applicant_bin: null
+    applicant_iban: null
+    applicant_name: null
+    bank_reference: null
+    currency: EUR
+    customer_reference: NONREF
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9oDEw==
+    entry_date: &id006 !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9oDEw==
+    extra_details: ''
+    funds_code: R
+    guessed_entry_date: *id006
+    id: N035
+    posting_text: Zahlung m.Elektr.Unterschr.
+    prima_nota: '991132'
+    purpose: 'Belegloser ZahlungsauftragErstellungsdatum:19.03.2010Anzahl Posten :      94Anw-Nr.:
+      69725563000'
+    recipient_name: null
+    return_debit_notes: '540'
+    status: D
+    transaction_code: '035'
+    transaction_reference: "STAR1\xDCT\xDFUMS"
+  transactions: *id004
+- !!python/object:mt940.models.Transaction
+  data:
+    additional_purpose: null
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '1120.00'
+      currency: EUR
+    applicant_bin: null
+    applicant_iban: null
+    applicant_name: null
+    bank_reference: null
+    currency: EUR
+    customer_reference: NONREF
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9oDFg==
+    entry_date: &id007 !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9oDEw==
+    extra_details: ''
+    funds_code: R
+    guessed_entry_date: *id007
+    id: N085
+    posting_text: Zahlung m.Elektr.Unterschr.
+    prima_nota: '991135'
+    purpose: "Belegloser Zahlungsauftrag\xDCberweisung:19.03.2010Anzahl Posten :7Anw-Nr.:\
+      \ 69725663086"
+    recipient_name: null
+    return_debit_notes: '540'
+    status: C
+    transaction_code: 085
+    transaction_reference: "STAR1\xDCTUMS"
+  transactions: *id004

--- a/mt940_tests/betterplace/with_binary_character.yml
+++ b/mt940_tests/betterplace/with_binary_character.yml
@@ -22,6 +22,18 @@ data:
   sequence_number: '00001'
   statement_number: '00053'
   transaction_reference: "STAR1\xDCTUMS"
+options: !!python/object/new:mt940.options.Options
+  state:
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
 tags:
   13: !!python/object:mt940.tags.DateTimeIndication
     re: !!python/object/apply:re._compile
@@ -115,8 +127,7 @@ transactions:
       - '27.00'
       currency: EUR
     applicant_bin: '50070010'
-    applicant_iban: '0175526300'
-    applicant_name: PAYPAL
+    applicant_name: 0175526300PAYPAL
     bank_reference: 32-P1-TCS49518
     currency: EUR
     customer_reference: 100323-03-100323
@@ -147,8 +158,7 @@ transactions:
       - '13068.30'
       currency: EUR
     applicant_bin: '51230800'
-    applicant_iban: '9990437808'
-    applicant_name: WIRECARD BANK AG
+    applicant_name: 9990437808WIRECARD BANK AG
     bank_reference: null
     currency: EUR
     customer_reference: NONREF
@@ -179,7 +189,6 @@ transactions:
       - '-193282.05'
       currency: EUR
     applicant_bin: null
-    applicant_iban: null
     applicant_name: null
     bank_reference: null
     currency: EUR
@@ -212,7 +221,6 @@ transactions:
       - '1120.00'
       currency: EUR
     applicant_bin: null
-    applicant_iban: null
     applicant_name: null
     bank_reference: null
     currency: EUR

--- a/mt940_tests/cmxl/account_balance_credit.yml
+++ b/mt940_tests/cmxl/account_balance_credit.yml
@@ -9,6 +9,18 @@ data:
     - !!binary |
       B94IHQ==
     status: C
+options: !!python/object/new:mt940.options.Options
+  state:
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
 tags:
   13: !!python/object:mt940.tags.DateTimeIndication
     re: !!python/object/apply:re._compile

--- a/mt940_tests/cmxl/account_balance_debit.yml
+++ b/mt940_tests/cmxl/account_balance_debit.yml
@@ -9,6 +9,18 @@ data:
     - !!binary |
       B94IHQ==
     status: D
+options: !!python/object/new:mt940.options.Options
+  state:
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
 tags:
   13: !!python/object:mt940.tags.DateTimeIndication
     re: !!python/object/apply:re._compile

--- a/mt940_tests/cmxl/account_identification_iban.yml
+++ b/mt940_tests/cmxl/account_identification_iban.yml
@@ -1,6 +1,18 @@
 !!python/object:mt940.models.Transactions
 data:
   account_identification: PL25106000760000888888888888
+options: !!python/object/new:mt940.options.Options
+  state:
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
 tags:
   13: !!python/object:mt940.tags.DateTimeIndication
     re: !!python/object/apply:re._compile

--- a/mt940_tests/cmxl/account_identification_legacy.yml
+++ b/mt940_tests/cmxl/account_identification_legacy.yml
@@ -1,6 +1,18 @@
 !!python/object:mt940.models.Transactions
 data:
   account_identification: 70011110/4005287001EUR
+options: !!python/object/new:mt940.options.Options
+  state:
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
 tags:
   13: !!python/object:mt940.tags.DateTimeIndication
     re: !!python/object/apply:re._compile

--- a/mt940_tests/cmxl/available_balance.yml
+++ b/mt940_tests/cmxl/available_balance.yml
@@ -9,6 +9,18 @@ data:
     - !!binary |
       B94JAQ==
     status: D
+options: !!python/object/new:mt940.options.Options
+  state:
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
 tags:
   13: !!python/object:mt940.tags.DateTimeIndication
     re: !!python/object/apply:re._compile

--- a/mt940_tests/cmxl/closing_balance.yml
+++ b/mt940_tests/cmxl/closing_balance.yml
@@ -9,6 +9,18 @@ data:
     - !!binary |
       B94JAQ==
     status: C
+options: !!python/object/new:mt940.options.Options
+  state:
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
 tags:
   13: !!python/object:mt940.tags.DateTimeIndication
     re: !!python/object/apply:re._compile

--- a/mt940_tests/cmxl/mt940.all.yml
+++ b/mt940_tests/cmxl/mt940.all.yml
@@ -1,0 +1,495 @@
+&id003 !!python/object:mt940.models.Transactions
+data:
+  account_identification: BPHKPLPK/320000546101
+  final_closing_balance: !!python/object:mt940.models.Balance
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '50040.00'
+      currency: PLN
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9IDGQ==
+    status: C
+  final_opening_balance: !!python/object:mt940.models.Balance
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '40000.00'
+      currency: PLN
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9MKAg==
+    status: C
+  related_reference: '9876543210'
+  sequence_number: '001'
+  statement_number: 00084
+  transaction_reference: TELEWIZORY S.A.
+options: !!python/object/new:mt940.options.Options
+  state:
+  - true
+  - true
+  - true
+  - true
+  - true
+  - true
+  - true
+  - true
+  - true
+  - true
+tags:
+  13: !!python/object:mt940.tags.DateTimeIndication
+    re: !!python/object/apply:re._compile
+    - "^\n    (?P<year>\\d{2})\n    (?P<month>\\d{2})\n    (?P<day>\\d{2})\n    (?P<hour>\\\
+      d{2})\n    (?P<minute>\\d{2})\n    ((?P<offset_sign>[+-])(?P<offset>\\d{4}))?\n\
+      \    "
+    - 98
+  20: !!python/object:mt940.tags.TransactionReferenceNumber
+    re: !!python/object/apply:re._compile
+    - (?P<transaction_reference>.{0,16})
+    - 98
+  21: !!python/object:mt940.tags.RelatedReference
+    re: !!python/object/apply:re._compile
+    - (?P<related_reference>.{0,16})
+    - 98
+  25: !!python/object:mt940.tags.AccountIdentification
+    re: !!python/object/apply:re._compile
+    - (?P<account_identification>.{0,35})
+    - 98
+  28: !!python/object:mt940.tags.StatementNumber
+    re: !!python/object/apply:re._compile
+    - "\n    (?P<statement_number>\\d{1,5})  # 5n\n    (?:/?(?P<sequence_number>\\\
+      d{1,5}))?  # [/5n]\n    $"
+    - 98
+  60: !!python/object:mt940.tags.OpeningBalance
+    re: &id001 !!python/object/apply:re._compile
+    - "^\n    (?P<status>[DC])  # 1!a Debit/Credit\n    (?P<year>\\d{2})  # 6!n Value\
+      \ Date (YYMMDD)\n    (?P<month>\\d{2})\n    (?P<day>\\d{2})\n    (?P<currency>.{3})\
+      \  # 3!a Currency\n    (?P<amount>[0-9,]{0,16})  # 15d Amount (includes decimal\
+      \ sign, so 16)\n    "
+    - 98
+  60M: !!python/object:mt940.tags.IntermediateOpeningBalance
+    re: *id001
+  60F: !!python/object:mt940.tags.FinalOpeningBalance
+    re: *id001
+  61: !!python/object:mt940.tags.Statement
+    re: !!python/object/apply:re._compile
+    - "^\n    (?P<year>\\d{2})  # 6!n Value Date (YYMMDD)\n    (?P<month>\\d{2})\n\
+      \    (?P<day>\\d{2})\n    (?P<entry_month>\\d{2}|\\s{2})?  # [4!n] Entry Date\
+      \ (MMDD)\n    (?P<entry_day>\\d{2}|\\s{2})?\n    (?P<status>R?[DC])  # 2a Debit/Credit\
+      \ Mark\n    (?P<funds_code>[A-Z])? # [1!a] Funds Code (3rd character of the\
+      \ currency\n                            # code, if needed)\n    [\\n ]?\n  \
+      \  (?P<amount>[\\d,]{1,15})  # 15d Amount\n    (?P<id>[A-Z][A-Z0-9 ]{3})?\n\
+      \    (?P<customer_reference>((?!//)[^\\n]){0,16})\n    (//(?P<bank_reference>.{0,23}))?\n\
+      \    # Supplementary details: the SWIFT spec caps this at 34x, but some banks\n\
+      \    # (e.g. Wise, issue #117) send more, so the length limit is relaxed. This\n\
+      \    # only ever turns a previous parse error into a successful parse.\n   \
+      \ (\\n?(?P<extra_details>.*))?\n    $"
+    - 98
+  62: !!python/object:mt940.tags.ClosingBalance
+    re: *id001
+  62M: !!python/object:mt940.tags.IntermediateClosingBalance
+    re: *id001
+  62F: !!python/object:mt940.tags.FinalClosingBalance
+    re: *id001
+  64: !!python/object:mt940.tags.AvailableBalance
+    re: *id001
+  65: !!python/object:mt940.tags.ForwardAvailableBalance
+    re: *id001
+  86: !!python/object:mt940.tags.TransactionDetails
+    re: !!python/object/apply:re._compile
+    - "\n    (?P<transaction_details>[\\s\\S]*)\n    "
+    - 98
+  34: !!python/object:mt940.tags.FloorLimitIndicator
+    re: !!python/object/apply:re._compile
+    - "^\n    (?P<currency>[A-Z]{3})  # 3!a Currency\n    (?P<status>[DC ]?)  # 2a\
+      \ Debit/Credit Mark\n    (?P<amount>[0-9,]{0,16})  # 15d Amount (includes decimal\
+      \ sign, so 16)\n    $"
+    - 98
+  NS: !!python/object:mt940.tags.NonSwift
+    re: !!python/object/apply:re._compile
+    - "\n    (?P<non_swift>[\\s\\S]*)\n    $"
+    - 98
+  90: !!python/object:mt940.tags.SumEntries
+    re: &id002 !!python/object/apply:re._compile
+    - "^\n    (?P<number>\\d*)\n    (?P<currency>.{3})  # 3!a Currency\n    (?P<amount>[\\\
+      d,]{1,15})  # 15d Amount\n    "
+    - 98
+  90D: !!python/object:mt940.tags.SumDebitEntries
+    re: *id002
+  90C: !!python/object:mt940.tags.SumCreditEntries
+    re: *id002
+transaction_boundary: !!python/object/apply:builtins.frozenset
+- []
+transactions:
+- !!python/object:mt940.models.Transaction
+  data:
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '-6800'
+      currency: DEM
+    bank_reference: null
+    currency: DEM
+    customer_reference: '16703074'
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B90KEQ==
+    extra_details: ''
+    funds_code: null
+    id: NCHK
+    status: D
+    transaction_details: 999PN5477SCHECK-NR. 0000016703074
+    transaction_reference: '131110'
+  transactions: *id003
+- !!python/object:mt940.models.Transaction
+  data:
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '-620.3'
+      currency: DEM
+    bank_reference: null
+    currency: DEM
+    customer_reference: N
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B90KEQ==
+    extra_details: ''
+    funds_code: null
+    id: NSTO
+    status: D
+    transaction_details: 999PN0911DAUERAUFTR.NR. 14
+    transaction_reference: '131110'
+  transactions: *id003
+- !!python/object:mt940.models.Transaction
+  data:
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '18500'
+      currency: DEM
+    bank_reference: null
+    currency: DEM
+    customer_reference: N
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B90KEQ==
+    extra_details: ''
+    funds_code: null
+    id: NCLR
+    status: C
+    transaction_details: 999PN2406SCHECK
+    transaction_reference: '131110'
+  transactions: *id003
+- !!python/object:mt940.models.Transaction
+  data:
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '-14220'
+      currency: DEM
+    bank_reference: null
+    currency: DEM
+    customer_reference: N
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B90KDw==
+    extra_details: ''
+    funds_code: null
+    id: NBOE
+    status: D
+    transaction_details: 999PN0920WECHSEL
+    transaction_reference: '131110'
+  transactions: *id003
+- !!python/object:mt940.models.Transaction
+  data:
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '-1507'
+      currency: DEM
+    bank_reference: null
+    currency: DEM
+    customer_reference: N
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B90KEQ==
+    extra_details: ''
+    funds_code: null
+    id: NTRF
+    status: D
+    transaction_details: 999PN0920SCHNELLUEB
+    transaction_reference: '131110'
+  transactions: *id003
+- !!python/object:mt940.models.Transaction
+  data:
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '4200'
+      currency: DEM
+    bank_reference: null
+    currency: DEM
+    customer_reference: N
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B90KGA==
+    extra_details: ''
+    funds_code: null
+    id: NMSC
+    status: C
+    transaction_details: 999PN2506AUSSENH. NR. 1
+    transaction_reference: '131110'
+  transactions: *id003
+- !!python/object:mt940.models.Transaction
+  data:
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '-19900'
+      currency: DEM
+    bank_reference: null
+    currency: DEM
+    customer_reference: N
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B90KEQ==
+    extra_details: ''
+    funds_code: null
+    id: NTRF
+    status: D
+    transaction_details: 999PN0907UEBERTRAG
+    transaction_reference: '131110'
+  transactions: *id003
+- !!python/object:mt940.models.Transaction
+  data:
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '-400'
+      currency: DEM
+    bank_reference: null
+    currency: DEM
+    customer_reference: N
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B90KEQ==
+    extra_details: ''
+    funds_code: null
+    id: NTRF
+    status: D
+    transaction_details: 999PN0891BTX
+    transaction_reference: '131110'
+  transactions: *id003
+- !!python/object:mt940.models.Transaction
+  data:
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '3656.74'
+      currency: DEM
+    bank_reference: null
+    currency: DEM
+    customer_reference: N
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B90KEg==
+    extra_details: ''
+    funds_code: null
+    id: NMSC
+    status: C
+    transaction_details: 999PN0850EINZAHLG.N
+    transaction_reference: '131110'
+  transactions: *id003
+- !!python/object:mt940.models.Transaction
+  data:
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '23040'
+      currency: DEM
+    bank_reference: null
+    currency: DEM
+    customer_reference: N
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B90KEw==
+    extra_details: ''
+    funds_code: null
+    id: NMSC
+    status: C
+    transaction_details: 999PN0812LT.ANLAGE
+    transaction_reference: '131110'
+  transactions: *id003
+- !!python/object:mt940.models.Transaction
+  data:
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '-5862.14'
+      currency: DEM
+    bank_reference: null
+    currency: DEM
+    customer_reference: N
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B90KGw==
+    extra_details: ''
+    funds_code: null
+    id: NCHK
+    status: D
+    transaction_details: 999PN5329AUSLSCHECK
+    transaction_reference: '131110'
+  transactions: *id003
+- !!python/object:mt940.models.Transaction
+  data:
+    additional_purpose: null
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '-800'
+      currency: EUR
+    applicant_bin: '10020030'
+    applicant_iban: '234567'
+    applicant_name: MUELLER
+    bank_reference: '55555'
+    currency: EUR
+    customer_reference: NONREF
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9ILAQ==
+    entry_date: &id004 !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9ILAg==
+    extra_details: ''
+    funds_code: R
+    guessed_entry_date: *id004
+    id: NSTO
+    posting_text: DAUERAUFTRAG
+    prima_nota: 0599
+    purpose: Miete November
+    recipient_name: null
+    return_debit_notes: '339'
+    status: D
+    transaction_code: 008
+    transaction_reference: '1234567'
+  transactions: *id003
+- !!python/object:mt940.models.Transaction
+  data:
+    additional_purpose: null
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '3000'
+      currency: EUR
+    applicant_bin: '50060400'
+    applicant_iban: 0847564700
+    applicant_name: MUELLER
+    bank_reference: '55555'
+    currency: EUR
+    customer_reference: NONREF
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9ILAg==
+    entry_date: &id005 !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9ILAg==
+    extra_details: ''
+    funds_code: R
+    guessed_entry_date: *id005
+    id: NTRF
+    posting_text: UEBERWEISUNG
+    prima_nota: 0599
+    purpose: Gehalt OktoberFirmaMustermannGmbH
+    recipient_name: null
+    return_debit_notes: '339'
+    status: C
+    transaction_code: '051'
+    transaction_reference: '1234567'
+  transactions: *id003
+- !!python/object:mt940.models.Transaction
+  data:
+    additional_purpose: null
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '20000.00'
+      currency: PLN
+    applicant_bin: '10600076'
+    applicant_iban: '0000777777777777'
+    applicant_name: HUTA SZKLA TOPIC ULPRZEMYSLOWA 67 32-669 WROCLAW
+    bank_reference: '8327000090031789'
+    currency: PLN
+    customer_reference: NONREF
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9MKFA==
+    entry_date: &id006 !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9MKFA==
+    extra_details: Card transaction
+    funds_code: null
+    guessed_entry_date: *id006
+    id: FMSC
+    posting_text: Wyplata-(dysp/przel)
+    prima_nota: null
+    purpose: 0810600076000077777777777715617INFO INFO INFO INFO INFO INFO 1 ENDINFO
+      INFO INFO INFO INFOINFO 2 ENDZAPLATA ZA FABRYKATY DO TUB - 200 S ZTUK, TRANZYSTORY-300
+      SZT GR544 I OPORNIKI-500 SZT GTX847 FAKTURA 333/2003.
+    recipient_name: null
+    return_debit_notes: null
+    status: C
+    transaction_code: '020'
+    transaction_reference: TELEWIZORY S.A.
+  transactions: *id003
+- !!python/object:mt940.models.Transaction
+  data:
+    additional_purpose: null
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '-10000.00'
+      currency: PLN
+    applicant_bin: '10600076'
+    applicant_iban: '0000777777777777'
+    applicant_name: null
+    bank_reference: '8327000090031790'
+    currency: PLN
+    customer_reference: REF 25611247
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9MKFA==
+    entry_date: &id007 !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9MKFA==
+    extra_details: Transfer
+    funds_code: null
+    guessed_entry_date: *id007
+    id: FTRF
+    posting_text: Wyplata-(dysp/przel)
+    prima_nota: null
+    purpose: 0810600076000077777777777715617INFO INFO INFO INFO INFO INFO 1 ENDINFO
+      INFO INFO INFO INFOINFO 2 ENDZAPLATA ZA FABRYKATY DO TUB - 200 S ZTUK, TRANZYSTORY-300
+      SZT GR544 I OPORNIKI-500 SZT GTX847 FAKTURA 333/2003.
+    recipient_name: null
+    return_debit_notes: null
+    status: D
+    transaction_code: '020'
+    transaction_reference: TELEWIZORY S.A.
+  transactions: *id003
+- !!python/object:mt940.models.Transaction
+  data:
+    additional_purpose: null
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '40.00'
+      currency: PLN
+    applicant_bin: null
+    applicant_iban: null
+    applicant_name: null
+    bank_reference: '8327000090031791'
+    currency: PLN
+    customer_reference: NONREF
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9MKFA==
+    entry_date: &id008 !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9MKFA==
+    extra_details: Interest credit
+    funds_code: null
+    guessed_entry_date: *id008
+    id: FTRF
+    posting_text: "Uznanie kwot\u0105 odsetek"
+    prima_nota: null
+    purpose: Odsetki od lokaty nr 101000022086
+    recipient_name: null
+    return_debit_notes: null
+    status: C
+    transaction_code: '844'
+    transaction_reference: TELEWIZORY S.A.
+  transactions: *id003

--- a/mt940_tests/cmxl/mt940.yml
+++ b/mt940_tests/cmxl/mt940.yml
@@ -23,6 +23,18 @@ data:
   sequence_number: '001'
   statement_number: 00084
   transaction_reference: TELEWIZORY S.A.
+options: !!python/object/new:mt940.options.Options
+  state:
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
 tags:
   13: !!python/object:mt940.tags.DateTimeIndication
     re: !!python/object/apply:re._compile
@@ -325,8 +337,7 @@ transactions:
       - '-800'
       currency: EUR
     applicant_bin: '10020030'
-    applicant_iban: '234567'
-    applicant_name: MUELLER
+    applicant_name: 234567MUELLER
     bank_reference: '55555'
     currency: EUR
     customer_reference: NONREF
@@ -357,8 +368,7 @@ transactions:
       - '3000'
       currency: EUR
     applicant_bin: '50060400'
-    applicant_iban: 0847564700
-    applicant_name: MUELLER
+    applicant_name: 0847564700MUELLER
     bank_reference: '55555'
     currency: EUR
     customer_reference: NONREF
@@ -389,8 +399,7 @@ transactions:
       - '20000.00'
       currency: PLN
     applicant_bin: '10600076'
-    applicant_iban: '0000777777777777'
-    applicant_name: HUTA SZKLA TOPIC ULPRZEMYSLOWA 67 32-669 WROCLAW
+    applicant_name: 0000777777777777HUTA SZKLA TOPIC ULPRZEMYSLOWA 67 32-669 WROCLAW
     bank_reference: '8327000090031789'
     currency: PLN
     customer_reference: NONREF
@@ -423,8 +432,7 @@ transactions:
       - '-10000.00'
       currency: PLN
     applicant_bin: '10600076'
-    applicant_iban: '0000777777777777'
-    applicant_name: null
+    applicant_name: '0000777777777777'
     bank_reference: '8327000090031790'
     currency: PLN
     customer_reference: REF 25611247
@@ -457,7 +465,6 @@ transactions:
       - '40.00'
       currency: PLN
     applicant_bin: null
-    applicant_iban: null
     applicant_name: null
     bank_reference: '8327000090031791'
     currency: PLN

--- a/mt940_tests/cmxl/reference.yml
+++ b/mt940_tests/cmxl/reference.yml
@@ -1,6 +1,18 @@
 !!python/object:mt940.models.Transactions
 data:
   transaction_reference: D140902049
+options: !!python/object/new:mt940.options.Options
+  state:
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
 tags:
   13: !!python/object:mt940.tags.DateTimeIndication
     re: !!python/object/apply:re._compile

--- a/mt940_tests/cmxl/statement_details.all.yml
+++ b/mt940_tests/cmxl/statement_details.all.yml
@@ -1,0 +1,146 @@
+&id004 !!python/object:mt940.models.Transactions
+data: {}
+options: !!python/object/new:mt940.options.Options
+  state:
+  - true
+  - true
+  - true
+  - true
+  - true
+  - true
+  - true
+  - true
+  - true
+  - true
+tags:
+  13: !!python/object:mt940.tags.DateTimeIndication
+    re: !!python/object/apply:re._compile
+    - "^\n    (?P<year>\\d{2})\n    (?P<month>\\d{2})\n    (?P<day>\\d{2})\n    (?P<hour>\\\
+      d{2})\n    (?P<minute>\\d{2})\n    ((?P<offset_sign>[+-])(?P<offset>\\d{4}))?\n\
+      \    "
+    - 98
+  20: !!python/object:mt940.tags.TransactionReferenceNumber
+    re: !!python/object/apply:re._compile
+    - (?P<transaction_reference>.{0,16})
+    - 98
+  21: !!python/object:mt940.tags.RelatedReference
+    re: !!python/object/apply:re._compile
+    - (?P<related_reference>.{0,16})
+    - 98
+  25: !!python/object:mt940.tags.AccountIdentification
+    re: !!python/object/apply:re._compile
+    - (?P<account_identification>.{0,35})
+    - 98
+  28: !!python/object:mt940.tags.StatementNumber
+    re: !!python/object/apply:re._compile
+    - "\n    (?P<statement_number>\\d{1,5})  # 5n\n    (?:/?(?P<sequence_number>\\\
+      d{1,5}))?  # [/5n]\n    $"
+    - 98
+  60: !!python/object:mt940.tags.OpeningBalance
+    re: &id001 !!python/object/apply:re._compile
+    - "^\n    (?P<status>[DC])  # 1!a Debit/Credit\n    (?P<year>\\d{2})  # 6!n Value\
+      \ Date (YYMMDD)\n    (?P<month>\\d{2})\n    (?P<day>\\d{2})\n    (?P<currency>.{3})\
+      \  # 3!a Currency\n    (?P<amount>[0-9,]{0,16})  # 15d Amount (includes decimal\
+      \ sign, so 16)\n    "
+    - 98
+  60M: !!python/object:mt940.tags.IntermediateOpeningBalance
+    re: *id001
+  60F: !!python/object:mt940.tags.FinalOpeningBalance
+    re: *id001
+  61: !!python/object:mt940.tags.Statement
+    re: !!python/object/apply:re._compile
+    - "^\n    (?P<year>\\d{2})  # 6!n Value Date (YYMMDD)\n    (?P<month>\\d{2})\n\
+      \    (?P<day>\\d{2})\n    (?P<entry_month>\\d{2}|\\s{2})?  # [4!n] Entry Date\
+      \ (MMDD)\n    (?P<entry_day>\\d{2}|\\s{2})?\n    (?P<status>R?[DC])  # 2a Debit/Credit\
+      \ Mark\n    (?P<funds_code>[A-Z])? # [1!a] Funds Code (3rd character of the\
+      \ currency\n                            # code, if needed)\n    [\\n ]?\n  \
+      \  (?P<amount>[\\d,]{1,15})  # 15d Amount\n    (?P<id>[A-Z][A-Z0-9 ]{3})?\n\
+      \    (?P<customer_reference>((?!//)[^\\n]){0,16})\n    (//(?P<bank_reference>.{0,23}))?\n\
+      \    # Supplementary details: the SWIFT spec caps this at 34x, but some banks\n\
+      \    # (e.g. Wise, issue #117) send more, so the length limit is relaxed. This\n\
+      \    # only ever turns a previous parse error into a successful parse.\n   \
+      \ (\\n?(?P<extra_details>.*))?\n    $"
+    - 98
+  62: !!python/object:mt940.tags.ClosingBalance
+    re: *id001
+  62M: !!python/object:mt940.tags.IntermediateClosingBalance
+    re: *id001
+  62F: !!python/object:mt940.tags.FinalClosingBalance
+    re: *id001
+  64: !!python/object:mt940.tags.AvailableBalance
+    re: *id001
+  65: !!python/object:mt940.tags.ForwardAvailableBalance
+    re: *id001
+  86: !!python/object:mt940.tags.TransactionDetails
+    re: !!python/object/apply:re._compile
+    - "\n    (?P<transaction_details>[\\s\\S]*)\n    "
+    - 98
+  34: !!python/object:mt940.tags.FloorLimitIndicator
+    re: !!python/object/apply:re._compile
+    - "^\n    (?P<currency>[A-Z]{3})  # 3!a Currency\n    (?P<status>[DC ]?)  # 2a\
+      \ Debit/Credit Mark\n    (?P<amount>[0-9,]{0,16})  # 15d Amount (includes decimal\
+      \ sign, so 16)\n    $"
+    - 98
+  NS: !!python/object:mt940.tags.NonSwift
+    re: !!python/object/apply:re._compile
+    - "\n    (?P<non_swift>[\\s\\S]*)\n    $"
+    - 98
+  90: !!python/object:mt940.tags.SumEntries
+    re: &id002 !!python/object/apply:re._compile
+    - "^\n    (?P<number>\\d*)\n    (?P<currency>.{3})  # 3!a Currency\n    (?P<amount>[\\\
+      d,]{1,15})  # 15d Amount\n    "
+    - 98
+  90D: !!python/object:mt940.tags.SumDebitEntries
+    re: *id002
+  90C: !!python/object:mt940.tags.SumCreditEntries
+    re: *id002
+transaction_boundary: !!python/object/apply:builtins.frozenset
+- []
+transactions:
+- !!python/object:mt940.models.Transaction
+  data:
+    FRST_ONE_OFF_RECC: null
+    additional_position_date: null
+    additional_position_reference: CAC97D2144174318AC18D9BF815BD4FB
+    additional_purpose: null
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '-1.62'
+      currency: null
+    applicant_bin: HYVEDEMMXXX
+    applicant_creditor_id: DE98ZZZ09999999999
+    applicant_iban: HUkkbbbsssskcccccccccccccccx
+    applicant_name: Peter Pan
+    bank_reference: 025498557/000001
+    compensation_amount: null
+    currency: null
+    customer_reference: 0000549855700010
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B94JAQ==
+    debitor_identifier: null
+    deviate_applicant: null
+    deviate_recipient: null
+    end_to_end_reference: TRX-0A4A47C3-F846-4729-8A1B-5DF620F
+    entry_date: &id003 !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B94JAg==
+    extra_details: ''
+    funds_code: R
+    guessed_entry_date: *id003
+    gvc_applicant_bin: null
+    gvc_applicant_iban: null
+    id: NTRF
+    old_SEPA_CI: null
+    old_SEPA_additional_position_reference: null
+    original_amount: null
+    posting_text: SEPA LASTSCHRIFT KUNDE
+    prima_nota: '281'
+    purpose: FOO TRX-0A4A47C3-F846-4729-8A1B-5DF620F
+    purpose_code: null
+    recipient_name: null
+    return_debit_notes: '171'
+    settlement_tag: null
+    status: D
+    transaction_code: '171'
+  transactions: *id004

--- a/mt940_tests/cmxl/statement_details.yml
+++ b/mt940_tests/cmxl/statement_details.yml
@@ -1,5 +1,17 @@
 &id004 !!python/object:mt940.models.Transactions
 data: {}
+options: !!python/object/new:mt940.options.Options
+  state:
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
 tags:
   13: !!python/object:mt940.tags.DateTimeIndication
     re: !!python/object/apply:re._compile
@@ -97,12 +109,11 @@ transactions:
       currency: null
     applicant_bin: HYVEDEMMXXX
     applicant_creditor_id: DE98ZZZ09999999999
-    applicant_iban: HUkkbbbsssskcccccccccccccccx
-    applicant_name: Peter Pan
+    applicant_name: HUkkbbbsssskcccccccccccccccxPeter Pan
     bank_reference: 025498557/000001
     compensation_amount: null
     currency: null
-    customer_reference: 0000549855700010
+    customer_reference: null
     date: !!python/object/apply:mt940.models.Date
     - !!binary |
       B94JAQ==

--- a/mt940_tests/cmxl/statement_line.yml
+++ b/mt940_tests/cmxl/statement_line.yml
@@ -1,5 +1,17 @@
 &id004 !!python/object:mt940.models.Transactions
 data: {}
+options: !!python/object/new:mt940.options.Options
+  state:
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
 tags:
   13: !!python/object:mt940.tags.DateTimeIndication
     re: !!python/object/apply:re._compile

--- a/mt940_tests/cmxl/statement_number.yml
+++ b/mt940_tests/cmxl/statement_number.yml
@@ -2,6 +2,18 @@
 data:
   sequence_number: '001'
   statement_number: '00035'
+options: !!python/object/new:mt940.options.Options
+  state:
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
 tags:
   13: !!python/object:mt940.tags.DateTimeIndication
     re: !!python/object/apply:re._compile

--- a/mt940_tests/jejik/abnamro.yml
+++ b/mt940_tests/jejik/abnamro.yml
@@ -40,6 +40,18 @@ data:
   sequence_number: '1'
   statement_number: '19322'
   transaction_reference: ABN AMRO BANK NV
+options: !!python/object/new:mt940.options.Options
+  state:
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
 tags:
   13: !!python/object:mt940.tags.DateTimeIndication
     re: !!python/object/apply:re._compile

--- a/mt940_tests/jejik/generic.yml
+++ b/mt940_tests/jejik/generic.yml
@@ -22,6 +22,18 @@ data:
   sequence_number: null
   statement_number: '2'
   transaction_reference: GENERIC
+options: !!python/object/new:mt940.options.Options
+  state:
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
 tags:
   13: !!python/object:mt940.tags.DateTimeIndication
     re: !!python/object/apply:re._compile

--- a/mt940_tests/jejik/ing.yml
+++ b/mt940_tests/jejik/ing.yml
@@ -22,6 +22,18 @@ data:
   sequence_number: null
   statement_number: '000'
   transaction_reference: MPBZ
+options: !!python/object/new:mt940.options.Options
+  state:
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
 tags:
   13: !!python/object:mt940.tags.DateTimeIndication
     re: !!python/object/apply:re._compile

--- a/mt940_tests/jejik/knab.yml
+++ b/mt940_tests/jejik/knab.yml
@@ -22,6 +22,18 @@ data:
   sequence_number: '1'
   statement_number: '999'
   transaction_reference: B4G30MS9D00A003D
+options: !!python/object/new:mt940.options.Options
+  state:
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
 tags:
   13: !!python/object:mt940.tags.DateTimeIndication
     re: !!python/object/apply:re._compile

--- a/mt940_tests/jejik/postfinance.yml
+++ b/mt940_tests/jejik/postfinance.yml
@@ -40,6 +40,18 @@ data:
   sequence_number: '2'
   statement_number: '999'
   transaction_reference: '2014040708285928'
+options: !!python/object/new:mt940.options.Options
+  state:
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
 tags:
   13: !!python/object:mt940.tags.DateTimeIndication
     re: !!python/object/apply:re._compile

--- a/mt940_tests/jejik/rabobank-iban.yml
+++ b/mt940_tests/jejik/rabobank-iban.yml
@@ -22,6 +22,18 @@ data:
   sequence_number: null
   statement_number: '0'
   transaction_reference: 940S130101
+options: !!python/object/new:mt940.options.Options
+  state:
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
 tags:
   13: !!python/object:mt940.tags.DateTimeIndication
     re: !!python/object/apply:re._compile

--- a/mt940_tests/jejik/rabobank.yml
+++ b/mt940_tests/jejik/rabobank.yml
@@ -22,6 +22,18 @@ data:
   sequence_number: '00'
   statement_number: '00000'
   transaction_reference: 940A120829
+options: !!python/object/new:mt940.options.Options
+  state:
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
 tags:
   13: !!python/object:mt940.tags.DateTimeIndication
     re: !!python/object/apply:re._compile

--- a/mt940_tests/jejik/sns.yml
+++ b/mt940_tests/jejik/sns.yml
@@ -22,6 +22,18 @@ data:
   sequence_number: '1'
   statement_number: '161'
   transaction_reference: '0000000000'
+options: !!python/object/new:mt940.options.Options
+  state:
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
 tags:
   13: !!python/object:mt940.tags.DateTimeIndication
     re: !!python/object/apply:re._compile

--- a/mt940_tests/jejik/triodos.yml
+++ b/mt940_tests/jejik/triodos.yml
@@ -22,6 +22,18 @@ data:
   sequence_number: null
   statement_number: '1'
   transaction_reference: 1308728725026/1
+options: !!python/object/new:mt940.options.Options
+  state:
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
 tags:
   13: !!python/object:mt940.tags.DateTimeIndication
     re: !!python/object/apply:re._compile

--- a/mt940_tests/mBank/mt940.yml
+++ b/mt940_tests/mBank/mt940.yml
@@ -31,6 +31,18 @@ data:
   sequence_number: '1'
   statement_number: '1'
   transaction_reference: ST170119CYC/1
+options: !!python/object/new:mt940.options.Options
+  state:
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
 tags:
   13: !!python/object:mt940.tags.DateTimeIndication
     re: !!python/object/apply:re._compile

--- a/mt940_tests/mBank/mt942.all.yml
+++ b/mt940_tests/mBank/mt942.all.yml
@@ -1,0 +1,218 @@
+&id004 !!python/object:mt940.models.Transactions
+data:
+  account_identification: PL29114010810000267002001002
+  c_floor_limit: !!python/object:mt940.models.Amount
+    amount: !!python/object/apply:decimal.Decimal
+    - '0'
+    currency: PLN
+  d_floor_limit: !!python/object:mt940.models.Amount
+    amount: !!python/object/apply:decimal.Decimal
+    - '0'
+    currency: PLN
+  date: !!python/object/apply:mt940.models.DateTime
+  - !!binary |
+    B+EBExIPAAAAAA==
+  - !!python/object/apply:mt940.models.FixedOffset
+    state:
+      _name: '60'
+      _offset: !!python/object/apply:datetime.timedelta
+      - 0
+      - 3600
+      - 0
+  sequence_number: '1'
+  statement_number: '1'
+  sum_credit_entries: !!python/object:mt940.models.SumAmount
+    amount: !!python/object/apply:decimal.Decimal
+    - '0.03'
+    currency: PLN
+    number: '3'
+  sum_debit_entries: !!python/object:mt940.models.SumAmount
+    amount: !!python/object/apply:decimal.Decimal
+    - '0.00'
+    currency: PLN
+    number: '0'
+  transaction_reference: ST170119CYC/0001
+options: !!python/object/new:mt940.options.Options
+  state:
+  - true
+  - true
+  - true
+  - true
+  - true
+  - true
+  - true
+  - true
+  - true
+  - true
+tags:
+  13: !!python/object:mt940.tags.DateTimeIndication
+    re: !!python/object/apply:re._compile
+    - "^\n    (?P<year>\\d{2})\n    (?P<month>\\d{2})\n    (?P<day>\\d{2})\n    (?P<hour>\\\
+      d{2})\n    (?P<minute>\\d{2})\n    ((?P<offset_sign>[+-])(?P<offset>\\d{4}))?\n\
+      \    "
+    - 98
+  20: !!python/object:mt940.tags.TransactionReferenceNumber
+    re: !!python/object/apply:re._compile
+    - (?P<transaction_reference>.{0,16})
+    - 98
+  21: !!python/object:mt940.tags.RelatedReference
+    re: !!python/object/apply:re._compile
+    - (?P<related_reference>.{0,16})
+    - 98
+  25: !!python/object:mt940.tags.AccountIdentification
+    re: !!python/object/apply:re._compile
+    - (?P<account_identification>.{0,35})
+    - 98
+  28: !!python/object:mt940.tags.StatementNumber
+    re: !!python/object/apply:re._compile
+    - "\n    (?P<statement_number>\\d{1,5})  # 5n\n    (?:/?(?P<sequence_number>\\\
+      d{1,5}))?  # [/5n]\n    $"
+    - 98
+  60: !!python/object:mt940.tags.OpeningBalance
+    re: &id001 !!python/object/apply:re._compile
+    - "^\n    (?P<status>[DC])  # 1!a Debit/Credit\n    (?P<year>\\d{2})  # 6!n Value\
+      \ Date (YYMMDD)\n    (?P<month>\\d{2})\n    (?P<day>\\d{2})\n    (?P<currency>.{3})\
+      \  # 3!a Currency\n    (?P<amount>[0-9,]{0,16})  # 15d Amount (includes decimal\
+      \ sign, so 16)\n    "
+    - 98
+  60M: !!python/object:mt940.tags.IntermediateOpeningBalance
+    re: *id001
+  60F: !!python/object:mt940.tags.FinalOpeningBalance
+    re: *id001
+  61: !!python/object:mt940.tags.Statement
+    re: !!python/object/apply:re._compile
+    - "^\n    (?P<year>\\d{2})  # 6!n Value Date (YYMMDD)\n    (?P<month>\\d{2})\n\
+      \    (?P<day>\\d{2})\n    (?P<entry_month>\\d{2}|\\s{2})?  # [4!n] Entry Date\
+      \ (MMDD)\n    (?P<entry_day>\\d{2}|\\s{2})?\n    (?P<status>R?[DC])  # 2a Debit/Credit\
+      \ Mark\n    (?P<funds_code>[A-Z])? # [1!a] Funds Code (3rd character of the\
+      \ currency\n                            # code, if needed)\n    [\\n ]?\n  \
+      \  (?P<amount>[\\d,]{1,15})  # 15d Amount\n    (?P<id>[A-Z][A-Z0-9 ]{3})?\n\
+      \    (?P<customer_reference>((?!//)[^\\n]){0,16})\n    (//(?P<bank_reference>.{0,23}))?\n\
+      \    # Supplementary details: the SWIFT spec caps this at 34x, but some banks\n\
+      \    # (e.g. Wise, issue #117) send more, so the length limit is relaxed. This\n\
+      \    # only ever turns a previous parse error into a successful parse.\n   \
+      \ (\\n?(?P<extra_details>.*))?\n    $"
+    - 98
+  62: !!python/object:mt940.tags.ClosingBalance
+    re: *id001
+  62M: !!python/object:mt940.tags.IntermediateClosingBalance
+    re: *id001
+  62F: !!python/object:mt940.tags.FinalClosingBalance
+    re: *id001
+  64: !!python/object:mt940.tags.AvailableBalance
+    re: *id001
+  65: !!python/object:mt940.tags.ForwardAvailableBalance
+    re: *id001
+  86: !!python/object:mt940.tags.TransactionDetails
+    re: !!python/object/apply:re._compile
+    - "\n    (?P<transaction_details>[\\s\\S]*)\n    "
+    - 98
+  34: !!python/object:mt940.tags.FloorLimitIndicator
+    re: !!python/object/apply:re._compile
+    - "^\n    (?P<currency>[A-Z]{3})  # 3!a Currency\n    (?P<status>[DC ]?)  # 2a\
+      \ Debit/Credit Mark\n    (?P<amount>[0-9,]{0,16})  # 15d Amount (includes decimal\
+      \ sign, so 16)\n    $"
+    - 98
+  NS: !!python/object:mt940.tags.NonSwift
+    re: !!python/object/apply:re._compile
+    - "\n    (?P<non_swift>[\\s\\S]*)\n    $"
+    - 98
+  90: !!python/object:mt940.tags.SumEntries
+    re: &id002 !!python/object/apply:re._compile
+    - "^\n    (?P<number>\\d*)\n    (?P<currency>.{3})  # 3!a Currency\n    (?P<amount>[\\\
+      d,]{1,15})  # 15d Amount\n    "
+    - 98
+  90D: !!python/object:mt940.tags.SumDebitEntries
+    re: *id002
+  90C: !!python/object:mt940.tags.SumCreditEntries
+    re: *id002
+transaction_boundary: !!python/object/apply:builtins.frozenset
+- []
+transactions:
+- !!python/object:mt940.models.Transaction
+  data:
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '0.01'
+      currency: PLN
+    bank_reference: MB170119012058
+    currency: PLN
+    customer_reference: NONREF
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B+EBEw==
+    entry_date: &id003 !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B+EBEw==
+    extra_details: 911-TRANSAKCJA IPH
+    funds_code: N
+    guessed_entry_date: *id003
+    id: NTRF
+    status: C
+    transaction_details: '911 TRANSAKCJA COLLECT; ID IPH: XX000000000001; Z RACH.:
+
+      56114010810000267002001001; OD: JAN NOWAK
+
+      UL. NIJAKA 1 M 2 31-234 KRAKOW; TYT.: PRZELEW SRODKOW   ;
+
+      TNR: 179171073864111.010001'
+    transaction_reference: ST170119CYC/0001
+  transactions: *id004
+- !!python/object:mt940.models.Transaction
+  data:
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '0.01'
+      currency: PLN
+    bank_reference: MB170119012085
+    currency: PLN
+    customer_reference: NONREF
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B+EBEw==
+    entry_date: &id005 !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B+EBEw==
+    extra_details: 911-TRANSAKCJA IPH
+    funds_code: N
+    guessed_entry_date: *id005
+    id: NTRF
+    status: C
+    transaction_details: '911 TRANSAKCJA COLLECT; ID IPH: XX000000000002; Z RACH.:
+
+      56114010810000267002001001; OD: JAN NOWAK
+
+      UL. NIJAKA 1 M 2 31-234 KRAKOW; TYT.: PRZELEW SRODKOW   ;
+
+      TNR: 179171073864192.000001'
+    transaction_reference: ST170119CYC/0001
+  transactions: *id004
+- !!python/object:mt940.models.Transaction
+  data:
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '0.01'
+      currency: PLN
+    bank_reference: MB170119012121
+    currency: PLN
+    customer_reference: NONREF
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B+EBEw==
+    entry_date: &id006 !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B+EBEw==
+    extra_details: 911-TRANSAKCJA IPH
+    funds_code: N
+    guessed_entry_date: *id006
+    id: NTRF
+    status: C
+    transaction_details: '911 TRANSAKCJA COLLECT; ID IPH: XX000000000003; Z RACH.:
+
+      56114010810000267002001001; OD: JAN NOWAK
+
+      UL. NIJAKA 1 M 2 31-234 KRAKOW; TYT.: PRZELEW SRODKOW   ;
+
+      TNR: 179171073864291.000001'
+    transaction_reference: ST170119CYC/0001
+  transactions: *id004

--- a/mt940_tests/mBank/mt942.yml
+++ b/mt940_tests/mBank/mt942.yml
@@ -14,10 +14,10 @@ data:
     B+EBExIPAAAAAA==
   - !!python/object/apply:mt940.models.FixedOffset
     state:
-      _name: '60'
+      _name: '0100'
       _offset: !!python/object/apply:datetime.timedelta
       - 0
-      - 3600
+      - 6000
       - 0
   sequence_number: '1'
   statement_number: '1'
@@ -32,6 +32,18 @@ data:
     currency: PLN
     number: '0'
   transaction_reference: ST170119CYC/0001
+options: !!python/object/new:mt940.options.Options
+  state:
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
 tags:
   13: !!python/object:mt940.tags.DateTimeIndication
     re: !!python/object/apply:re._compile

--- a/mt940_tests/mBank/with_newline_in_tnr.yml
+++ b/mt940_tests/mBank/with_newline_in_tnr.yml
@@ -31,6 +31,18 @@ data:
   sequence_number: '1'
   statement_number: '3'
   transaction_reference: ST170201CYC/1
+options: !!python/object/new:mt940.options.Options
+  state:
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
 tags:
   13: !!python/object:mt940.tags.DateTimeIndication
     re: !!python/object/apply:re._compile

--- a/mt940_tests/sberbank/171011_01234945.yml
+++ b/mt940_tests/sberbank/171011_01234945.yml
@@ -59,6 +59,18 @@ data:
   sequence_number: null
   statement_number: '00046'
   transaction_reference: STARTUMS
+options: !!python/object/new:mt940.options.Options
+  state:
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
 tags:
   13: !!python/object:mt940.tags.DateTimeIndication
     re: !!python/object/apply:re._compile

--- a/mt940_tests/self-provided/account_identification.yml
+++ b/mt940_tests/self-provided/account_identification.yml
@@ -2,6 +2,18 @@
 data:
   account_identification: ACXXXXXX000000XXXXXX3
   transaction_reference: 0003478756
+options: !!python/object/new:mt940.options.Options
+  state:
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
 tags:
   13: !!python/object:mt940.tags.DateTimeIndication
     re: !!python/object/apply:re._compile

--- a/mt940_tests/self-provided/details_60-63.all.yml
+++ b/mt940_tests/self-provided/details_60-63.all.yml
@@ -1,0 +1,166 @@
+&id003 !!python/object:mt940.models.Transactions
+data:
+  account_identification: 12345678/1020304050
+  final_closing_balance: !!python/object:mt940.models.Balance
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '12345.98'
+      currency: EUR
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B+EJDg==
+    status: C
+  final_opening_balance: !!python/object:mt940.models.Balance
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '12345.12'
+      currency: EUR
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B+EJDg==
+    status: C
+  sequence_number: null
+  statement_number: '0'
+  transaction_reference: STARTUMS
+options: !!python/object/new:mt940.options.Options
+  state:
+  - true
+  - true
+  - true
+  - true
+  - true
+  - true
+  - true
+  - true
+  - true
+  - true
+tags:
+  13: !!python/object:mt940.tags.DateTimeIndication
+    re: !!python/object/apply:re._compile
+    - "^\n    (?P<year>\\d{2})\n    (?P<month>\\d{2})\n    (?P<day>\\d{2})\n    (?P<hour>\\\
+      d{2})\n    (?P<minute>\\d{2})\n    ((?P<offset_sign>[+-])(?P<offset>\\d{4}))?\n\
+      \    "
+    - 98
+  20: !!python/object:mt940.tags.TransactionReferenceNumber
+    re: !!python/object/apply:re._compile
+    - (?P<transaction_reference>.{0,16})
+    - 98
+  21: !!python/object:mt940.tags.RelatedReference
+    re: !!python/object/apply:re._compile
+    - (?P<related_reference>.{0,16})
+    - 98
+  25: !!python/object:mt940.tags.AccountIdentification
+    re: !!python/object/apply:re._compile
+    - (?P<account_identification>.{0,35})
+    - 98
+  28: !!python/object:mt940.tags.StatementNumber
+    re: !!python/object/apply:re._compile
+    - "\n    (?P<statement_number>\\d{1,5})  # 5n\n    (?:/?(?P<sequence_number>\\\
+      d{1,5}))?  # [/5n]\n    $"
+    - 98
+  60: !!python/object:mt940.tags.OpeningBalance
+    re: &id001 !!python/object/apply:re._compile
+    - "^\n    (?P<status>[DC])  # 1!a Debit/Credit\n    (?P<year>\\d{2})  # 6!n Value\
+      \ Date (YYMMDD)\n    (?P<month>\\d{2})\n    (?P<day>\\d{2})\n    (?P<currency>.{3})\
+      \  # 3!a Currency\n    (?P<amount>[0-9,]{0,16})  # 15d Amount (includes decimal\
+      \ sign, so 16)\n    "
+    - 98
+  60M: !!python/object:mt940.tags.IntermediateOpeningBalance
+    re: *id001
+  60F: !!python/object:mt940.tags.FinalOpeningBalance
+    re: *id001
+  61: !!python/object:mt940.tags.Statement
+    re: !!python/object/apply:re._compile
+    - "^\n    (?P<year>\\d{2})  # 6!n Value Date (YYMMDD)\n    (?P<month>\\d{2})\n\
+      \    (?P<day>\\d{2})\n    (?P<entry_month>\\d{2}|\\s{2})?  # [4!n] Entry Date\
+      \ (MMDD)\n    (?P<entry_day>\\d{2}|\\s{2})?\n    (?P<status>R?[DC])  # 2a Debit/Credit\
+      \ Mark\n    (?P<funds_code>[A-Z])? # [1!a] Funds Code (3rd character of the\
+      \ currency\n                            # code, if needed)\n    [\\n ]?\n  \
+      \  (?P<amount>[\\d,]{1,15})  # 15d Amount\n    (?P<id>[A-Z][A-Z0-9 ]{3})?\n\
+      \    (?P<customer_reference>((?!//)[^\\n]){0,16})\n    (//(?P<bank_reference>.{0,23}))?\n\
+      \    # Supplementary details: the SWIFT spec caps this at 34x, but some banks\n\
+      \    # (e.g. Wise, issue #117) send more, so the length limit is relaxed. This\n\
+      \    # only ever turns a previous parse error into a successful parse.\n   \
+      \ (\\n?(?P<extra_details>.*))?\n    $"
+    - 98
+  62: !!python/object:mt940.tags.ClosingBalance
+    re: *id001
+  62M: !!python/object:mt940.tags.IntermediateClosingBalance
+    re: *id001
+  62F: !!python/object:mt940.tags.FinalClosingBalance
+    re: *id001
+  64: !!python/object:mt940.tags.AvailableBalance
+    re: *id001
+  65: !!python/object:mt940.tags.ForwardAvailableBalance
+    re: *id001
+  86: !!python/object:mt940.tags.TransactionDetails
+    re: !!python/object/apply:re._compile
+    - "\n    (?P<transaction_details>[\\s\\S]*)\n    "
+    - 98
+  34: !!python/object:mt940.tags.FloorLimitIndicator
+    re: !!python/object/apply:re._compile
+    - "^\n    (?P<currency>[A-Z]{3})  # 3!a Currency\n    (?P<status>[DC ]?)  # 2a\
+      \ Debit/Credit Mark\n    (?P<amount>[0-9,]{0,16})  # 15d Amount (includes decimal\
+      \ sign, so 16)\n    $"
+    - 98
+  NS: !!python/object:mt940.tags.NonSwift
+    re: !!python/object/apply:re._compile
+    - "\n    (?P<non_swift>[\\s\\S]*)\n    $"
+    - 98
+  90: !!python/object:mt940.tags.SumEntries
+    re: &id002 !!python/object/apply:re._compile
+    - "^\n    (?P<number>\\d*)\n    (?P<currency>.{3})  # 3!a Currency\n    (?P<amount>[\\\
+      d,]{1,15})  # 15d Amount\n    "
+    - 98
+  90D: !!python/object:mt940.tags.SumDebitEntries
+    re: *id002
+  90C: !!python/object:mt940.tags.SumCreditEntries
+    re: *id002
+transaction_boundary: !!python/object/apply:builtins.frozenset
+- []
+transactions:
+- !!python/object:mt940.models.Transaction
+  data:
+    FRST_ONE_OFF_RECC: null
+    additional_position_date: null
+    additional_position_reference: null
+    additional_purpose: '000000012345 BIC: BYLADEMMABWA: Finanzamt Muenchen ABWA+Finanzamt
+      MuenchenAbteilung Erhebung'
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '-233.15'
+      currency: EUR
+    applicant_bin: BYLADEMM
+    applicant_creditor_id: null
+    applicant_iban: DE99700500000000012345
+    applicant_name: Finanzamt Muenchen Abteilung Erhebung
+    bank_reference: null
+    compensation_amount: null
+    currency: EUR
+    customer_reference: ''
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B+EJDg==
+    debitor_identifier: null
+    deviate_applicant: null
+    deviate_recipient: null
+    end_to_end_reference: 123/123/12345-----L110
+    extra_details: ''
+    funds_code: null
+    gvc_applicant_bin: null
+    gvc_applicant_iban: null
+    id: NMSC
+    old_SEPA_CI: null
+    old_SEPA_additional_position_reference: null
+    original_amount: null
+    posting_text: Basislastschrift
+    prima_nota: '931'
+    purpose: null
+    purpose_code: null
+    recipient_name: null
+    return_debit_notes: '992'
+    settlement_tag: null
+    status: D
+    transaction_code: '105'
+    transaction_reference: STARTUMS
+  transactions: *id003

--- a/mt940_tests/self-provided/details_60-63.yml
+++ b/mt940_tests/self-provided/details_60-63.yml
@@ -22,6 +22,18 @@ data:
   sequence_number: null
   statement_number: '0'
   transaction_reference: STARTUMS
+options: !!python/object/new:mt940.options.Options
+  state:
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
 tags:
   13: !!python/object:mt940.tags.DateTimeIndication
     re: !!python/object/apply:re._compile
@@ -120,12 +132,11 @@ transactions:
       currency: EUR
     applicant_bin: BYLADEMM
     applicant_creditor_id: null
-    applicant_iban: DE99700500000000012345
-    applicant_name: Finanzamt Muenchen Abteilung Erhebung
+    applicant_name: DE99700500000000012345Finanzamt Muenchen Abteilung Erhebung
     bank_reference: null
     compensation_amount: null
     currency: EUR
-    customer_reference: ''
+    customer_reference: null
     date: !!python/object/apply:mt940.models.Date
     - !!binary |
       B+EJDg==

--- a/mt940_tests/self-provided/empty_non_swift.yml
+++ b/mt940_tests/self-provided/empty_non_swift.yml
@@ -2,6 +2,18 @@
 data:
   non_swift: ''
   non_swift_text: ''
+options: !!python/object/new:mt940.options.Options
+  state:
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
 tags:
   13: !!python/object:mt940.tags.DateTimeIndication
     re: !!python/object/apply:re._compile

--- a/mt940_tests/self-provided/february_30.all.yml
+++ b/mt940_tests/self-provided/february_30.all.yml
@@ -1,0 +1,153 @@
+&id004 !!python/object:mt940.models.Transactions
+data:
+  account_identification: 12345678/1020304050
+  final_closing_balance: !!python/object:mt940.models.Balance
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '1194.00'
+      currency: EUR
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B+ADAQ==
+    status: C
+  final_opening_balance: !!python/object:mt940.models.Balance
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '1200.00'
+      currency: EUR
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B+ACHQ==
+    status: C
+  sequence_number: '001'
+  statement_number: '00000'
+  transaction_reference: STARTUMSE
+options: !!python/object/new:mt940.options.Options
+  state:
+  - true
+  - true
+  - true
+  - true
+  - true
+  - true
+  - true
+  - true
+  - true
+  - true
+tags:
+  13: !!python/object:mt940.tags.DateTimeIndication
+    re: !!python/object/apply:re._compile
+    - "^\n    (?P<year>\\d{2})\n    (?P<month>\\d{2})\n    (?P<day>\\d{2})\n    (?P<hour>\\\
+      d{2})\n    (?P<minute>\\d{2})\n    ((?P<offset_sign>[+-])(?P<offset>\\d{4}))?\n\
+      \    "
+    - 98
+  20: !!python/object:mt940.tags.TransactionReferenceNumber
+    re: !!python/object/apply:re._compile
+    - (?P<transaction_reference>.{0,16})
+    - 98
+  21: !!python/object:mt940.tags.RelatedReference
+    re: !!python/object/apply:re._compile
+    - (?P<related_reference>.{0,16})
+    - 98
+  25: !!python/object:mt940.tags.AccountIdentification
+    re: !!python/object/apply:re._compile
+    - (?P<account_identification>.{0,35})
+    - 98
+  28: !!python/object:mt940.tags.StatementNumber
+    re: !!python/object/apply:re._compile
+    - "\n    (?P<statement_number>\\d{1,5})  # 5n\n    (?:/?(?P<sequence_number>\\\
+      d{1,5}))?  # [/5n]\n    $"
+    - 98
+  60: !!python/object:mt940.tags.OpeningBalance
+    re: &id001 !!python/object/apply:re._compile
+    - "^\n    (?P<status>[DC])  # 1!a Debit/Credit\n    (?P<year>\\d{2})  # 6!n Value\
+      \ Date (YYMMDD)\n    (?P<month>\\d{2})\n    (?P<day>\\d{2})\n    (?P<currency>.{3})\
+      \  # 3!a Currency\n    (?P<amount>[0-9,]{0,16})  # 15d Amount (includes decimal\
+      \ sign, so 16)\n    "
+    - 98
+  60M: !!python/object:mt940.tags.IntermediateOpeningBalance
+    re: *id001
+  60F: !!python/object:mt940.tags.FinalOpeningBalance
+    re: *id001
+  61: !!python/object:mt940.tags.Statement
+    re: !!python/object/apply:re._compile
+    - "^\n    (?P<year>\\d{2})  # 6!n Value Date (YYMMDD)\n    (?P<month>\\d{2})\n\
+      \    (?P<day>\\d{2})\n    (?P<entry_month>\\d{2}|\\s{2})?  # [4!n] Entry Date\
+      \ (MMDD)\n    (?P<entry_day>\\d{2}|\\s{2})?\n    (?P<status>R?[DC])  # 2a Debit/Credit\
+      \ Mark\n    (?P<funds_code>[A-Z])? # [1!a] Funds Code (3rd character of the\
+      \ currency\n                            # code, if needed)\n    [\\n ]?\n  \
+      \  (?P<amount>[\\d,]{1,15})  # 15d Amount\n    (?P<id>[A-Z][A-Z0-9 ]{3})?\n\
+      \    (?P<customer_reference>((?!//)[^\\n]){0,16})\n    (//(?P<bank_reference>.{0,23}))?\n\
+      \    # Supplementary details: the SWIFT spec caps this at 34x, but some banks\n\
+      \    # (e.g. Wise, issue #117) send more, so the length limit is relaxed. This\n\
+      \    # only ever turns a previous parse error into a successful parse.\n   \
+      \ (\\n?(?P<extra_details>.*))?\n    $"
+    - 98
+  62: !!python/object:mt940.tags.ClosingBalance
+    re: *id001
+  62M: !!python/object:mt940.tags.IntermediateClosingBalance
+    re: *id001
+  62F: !!python/object:mt940.tags.FinalClosingBalance
+    re: *id001
+  64: !!python/object:mt940.tags.AvailableBalance
+    re: *id001
+  65: !!python/object:mt940.tags.ForwardAvailableBalance
+    re: *id001
+  86: !!python/object:mt940.tags.TransactionDetails
+    re: !!python/object/apply:re._compile
+    - "\n    (?P<transaction_details>[\\s\\S]*)\n    "
+    - 98
+  34: !!python/object:mt940.tags.FloorLimitIndicator
+    re: !!python/object/apply:re._compile
+    - "^\n    (?P<currency>[A-Z]{3})  # 3!a Currency\n    (?P<status>[DC ]?)  # 2a\
+      \ Debit/Credit Mark\n    (?P<amount>[0-9,]{0,16})  # 15d Amount (includes decimal\
+      \ sign, so 16)\n    $"
+    - 98
+  NS: !!python/object:mt940.tags.NonSwift
+    re: !!python/object/apply:re._compile
+    - "\n    (?P<non_swift>[\\s\\S]*)\n    $"
+    - 98
+  90: !!python/object:mt940.tags.SumEntries
+    re: &id002 !!python/object/apply:re._compile
+    - "^\n    (?P<number>\\d*)\n    (?P<currency>.{3})  # 3!a Currency\n    (?P<amount>[\\\
+      d,]{1,15})  # 15d Amount\n    "
+    - 98
+  90D: !!python/object:mt940.tags.SumDebitEntries
+    re: *id002
+  90C: !!python/object:mt940.tags.SumCreditEntries
+    re: *id002
+transaction_boundary: !!python/object/apply:builtins.frozenset
+- []
+transactions:
+- !!python/object:mt940.models.Transaction
+  data:
+    additional_purpose: null
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '-6.00'
+      currency: EUR
+    applicant_bin: '12345678'
+    applicant_iban: null
+    applicant_name: null
+    bank_reference: null
+    currency: EUR
+    customer_reference: NONREF
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B+ACHQ==
+    entry_date: &id003 !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B+ADAQ==
+    extra_details: ''
+    funds_code: R
+    guessed_entry_date: *id003
+    id: N024
+    posting_text: ENTGELTABSCHLUSS
+    prima_nota: '6666'
+    purpose: Pauschalen
+    recipient_name: null
+    return_debit_notes: null
+    status: D
+    transaction_code: '805'
+    transaction_reference: STARTUMSE
+  transactions: *id004

--- a/mt940_tests/self-provided/february_30.yml
+++ b/mt940_tests/self-provided/february_30.yml
@@ -22,6 +22,18 @@ data:
   sequence_number: '001'
   statement_number: '00000'
   transaction_reference: STARTUMSE
+options: !!python/object/new:mt940.options.Options
+  state:
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
 tags:
   13: !!python/object:mt940.tags.DateTimeIndication
     re: !!python/object/apply:re._compile
@@ -115,7 +127,6 @@ transactions:
       - '-6.00'
       currency: EUR
     applicant_bin: '12345678'
-    applicant_iban: null
     applicant_name: null
     bank_reference: null
     currency: EUR

--- a/mt940_tests/self-provided/gv_codes.all.yml
+++ b/mt940_tests/self-provided/gv_codes.all.yml
@@ -1,0 +1,178 @@
+&id003 !!python/object:mt940.models.Transactions
+data:
+  account_identification: 12345678/1020304050
+  final_opening_balance: !!python/object:mt940.models.Balance
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '12345.12'
+      currency: EUR
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B+EJDg==
+    status: C
+  sequence_number: null
+  statement_number: '0'
+  transaction_reference: STARTUMS
+options: !!python/object/new:mt940.options.Options
+  state:
+  - true
+  - true
+  - true
+  - true
+  - true
+  - true
+  - true
+  - true
+  - true
+  - true
+tags:
+  13: !!python/object:mt940.tags.DateTimeIndication
+    re: !!python/object/apply:re._compile
+    - "^\n    (?P<year>\\d{2})\n    (?P<month>\\d{2})\n    (?P<day>\\d{2})\n    (?P<hour>\\\
+      d{2})\n    (?P<minute>\\d{2})\n    ((?P<offset_sign>[+-])(?P<offset>\\d{4}))?\n\
+      \    "
+    - 98
+  20: !!python/object:mt940.tags.TransactionReferenceNumber
+    re: !!python/object/apply:re._compile
+    - (?P<transaction_reference>.{0,16})
+    - 98
+  21: !!python/object:mt940.tags.RelatedReference
+    re: !!python/object/apply:re._compile
+    - (?P<related_reference>.{0,16})
+    - 98
+  25: !!python/object:mt940.tags.AccountIdentification
+    re: !!python/object/apply:re._compile
+    - (?P<account_identification>.{0,35})
+    - 98
+  28: !!python/object:mt940.tags.StatementNumber
+    re: !!python/object/apply:re._compile
+    - "\n    (?P<statement_number>\\d{1,5})  # 5n\n    (?:/?(?P<sequence_number>\\\
+      d{1,5}))?  # [/5n]\n    $"
+    - 98
+  60: !!python/object:mt940.tags.OpeningBalance
+    re: &id001 !!python/object/apply:re._compile
+    - "^\n    (?P<status>[DC])  # 1!a Debit/Credit\n    (?P<year>\\d{2})  # 6!n Value\
+      \ Date (YYMMDD)\n    (?P<month>\\d{2})\n    (?P<day>\\d{2})\n    (?P<currency>.{3})\
+      \  # 3!a Currency\n    (?P<amount>[0-9,]{0,16})  # 15d Amount (includes decimal\
+      \ sign, so 16)\n    "
+    - 98
+  60M: !!python/object:mt940.tags.IntermediateOpeningBalance
+    re: *id001
+  60F: !!python/object:mt940.tags.FinalOpeningBalance
+    re: *id001
+  61: !!python/object:mt940.tags.Statement
+    re: !!python/object/apply:re._compile
+    - "^\n    (?P<year>\\d{2})  # 6!n Value Date (YYMMDD)\n    (?P<month>\\d{2})\n\
+      \    (?P<day>\\d{2})\n    (?P<entry_month>\\d{2}|\\s{2})?  # [4!n] Entry Date\
+      \ (MMDD)\n    (?P<entry_day>\\d{2}|\\s{2})?\n    (?P<status>R?[DC])  # 2a Debit/Credit\
+      \ Mark\n    (?P<funds_code>[A-Z])? # [1!a] Funds Code (3rd character of the\
+      \ currency\n                            # code, if needed)\n    [\\n ]?\n  \
+      \  (?P<amount>[\\d,]{1,15})  # 15d Amount\n    (?P<id>[A-Z][A-Z0-9 ]{3})?\n\
+      \    (?P<customer_reference>((?!//)[^\\n]){0,16})\n    (//(?P<bank_reference>.{0,23}))?\n\
+      \    # Supplementary details: the SWIFT spec caps this at 34x, but some banks\n\
+      \    # (e.g. Wise, issue #117) send more, so the length limit is relaxed. This\n\
+      \    # only ever turns a previous parse error into a successful parse.\n   \
+      \ (\\n?(?P<extra_details>.*))?\n    $"
+    - 98
+  62: !!python/object:mt940.tags.ClosingBalance
+    re: *id001
+  62M: !!python/object:mt940.tags.IntermediateClosingBalance
+    re: *id001
+  62F: !!python/object:mt940.tags.FinalClosingBalance
+    re: *id001
+  64: !!python/object:mt940.tags.AvailableBalance
+    re: *id001
+  65: !!python/object:mt940.tags.ForwardAvailableBalance
+    re: *id001
+  86: !!python/object:mt940.tags.TransactionDetails
+    re: !!python/object/apply:re._compile
+    - "\n    (?P<transaction_details>[\\s\\S]*)\n    "
+    - 98
+  34: !!python/object:mt940.tags.FloorLimitIndicator
+    re: !!python/object/apply:re._compile
+    - "^\n    (?P<currency>[A-Z]{3})  # 3!a Currency\n    (?P<status>[DC ]?)  # 2a\
+      \ Debit/Credit Mark\n    (?P<amount>[0-9,]{0,16})  # 15d Amount (includes decimal\
+      \ sign, so 16)\n    $"
+    - 98
+  NS: !!python/object:mt940.tags.NonSwift
+    re: !!python/object/apply:re._compile
+    - "\n    (?P<non_swift>[\\s\\S]*)\n    $"
+    - 98
+  90: !!python/object:mt940.tags.SumEntries
+    re: &id002 !!python/object/apply:re._compile
+    - "^\n    (?P<number>\\d*)\n    (?P<currency>.{3})  # 3!a Currency\n    (?P<amount>[\\\
+      d,]{1,15})  # 15d Amount\n    "
+    - 98
+  90D: !!python/object:mt940.tags.SumDebitEntries
+    re: *id002
+  90C: !!python/object:mt940.tags.SumCreditEntries
+    re: *id002
+transaction_boundary: !!python/object/apply:builtins.frozenset
+- []
+transactions:
+- !!python/object:mt940.models.Transaction
+  data:
+    FRST_ONE_OFF_RECC: null
+    additional_position_date: null
+    additional_position_reference: ' 12AB234CD6E7F '
+    additional_purpose: null
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '-233.15'
+      currency: EUR
+    applicant_bin: null
+    applicant_creditor_id: ' AB12CDE0000000000000000034 '
+    applicant_iban: null
+    applicant_name: PayPal (Europe) S.a.r.l. et
+    bank_reference: null
+    compensation_amount: null
+    currency: EUR
+    customer_reference: ''
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B+EJDg==
+    debitor_identifier: null
+    deviate_applicant: null
+    deviate_recipient: null
+    end_to_end_reference: ' 1234567890123 PAYPAL'
+    extra_details: ''
+    funds_code: null
+    gvc_applicant_bin: null
+    gvc_applicant_iban: null
+    id: NMSC
+    old_SEPA_CI: null
+    old_SEPA_additional_position_reference: null
+    original_amount: null
+    posting_text: null
+    prima_nota: null
+    purpose: ' . SPOTIFY, Ihr Einkaufbei SPOTIFY'
+    purpose_code: null
+    recipient_name: null
+    return_debit_notes: null
+    settlement_tag: null
+    status: D
+    transaction_code: '835'
+    transaction_reference: STARTUMS
+  transactions: *id003
+- !!python/object:mt940.models.Transaction
+  data:
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '-24.30'
+      currency: EUR
+    bank_reference: null
+    currency: EUR
+    customer_reference: NONREF
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B+MKGQ==
+    entry_date: &id004 !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B+MKGQ==
+    extra_details: ''
+    funds_code: null
+    guessed_entry_date: *id004
+    id: NMSC
+    status: D
+    transaction_reference: STARTUMS
+  transactions: *id003

--- a/mt940_tests/self-provided/gv_codes.yml
+++ b/mt940_tests/self-provided/gv_codes.yml
@@ -13,6 +13,18 @@ data:
   sequence_number: null
   statement_number: '0'
   transaction_reference: STARTUMS
+options: !!python/object/new:mt940.options.Options
+  state:
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
 tags:
   13: !!python/object:mt940.tags.DateTimeIndication
     re: !!python/object/apply:re._compile
@@ -110,12 +122,11 @@ transactions:
       currency: EUR
     applicant_bin: null
     applicant_creditor_id: ' AB12CDE0000000000000000034 '
-    applicant_iban: null
     applicant_name: PayPal (Europe) S.a.r.l. et
     bank_reference: null
     compensation_amount: null
     currency: EUR
-    customer_reference: ''
+    customer_reference: null
     date: !!python/object/apply:mt940.models.Date
     - !!binary |
       B+EJDg==

--- a/mt940_tests/self-provided/invalid_statement.yml
+++ b/mt940_tests/self-provided/invalid_statement.yml
@@ -1,5 +1,17 @@
 !!python/object:mt940.models.Transactions
 data: {}
+options: !!python/object/new:mt940.options.Options
+  state:
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
 tags:
   13: !!python/object:mt940.tags.DateTimeIndication
     re: !!python/object/apply:re._compile

--- a/mt940_tests/self-provided/long_statement_number.yml
+++ b/mt940_tests/self-provided/long_statement_number.yml
@@ -22,6 +22,18 @@ data:
   sequence_number: '18101'
   statement_number: '18101'
   transaction_reference: '12345678'
+options: !!python/object/new:mt940.options.Options
+  state:
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
 tags:
   13: !!python/object:mt940.tags.DateTimeIndication
     re: !!python/object/apply:re._compile

--- a/mt940_tests/self-provided/malformed_details.all.yml
+++ b/mt940_tests/self-provided/malformed_details.all.yml
@@ -1,0 +1,167 @@
+&id003 !!python/object:mt940.models.Transactions
+data:
+  account_identification: 12345678/1020304050
+  final_closing_balance: !!python/object:mt940.models.Balance
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '12345.98'
+      currency: EUR
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B+EJDg==
+    status: C
+  final_opening_balance: !!python/object:mt940.models.Balance
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '12345.12'
+      currency: EUR
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B+EJDg==
+    status: C
+  sequence_number: null
+  statement_number: '0'
+  transaction_reference: STARTUMS
+options: !!python/object/new:mt940.options.Options
+  state:
+  - true
+  - true
+  - true
+  - true
+  - true
+  - true
+  - true
+  - true
+  - true
+  - true
+tags:
+  13: !!python/object:mt940.tags.DateTimeIndication
+    re: !!python/object/apply:re._compile
+    - "^\n    (?P<year>\\d{2})\n    (?P<month>\\d{2})\n    (?P<day>\\d{2})\n    (?P<hour>\\\
+      d{2})\n    (?P<minute>\\d{2})\n    ((?P<offset_sign>[+-])(?P<offset>\\d{4}))?\n\
+      \    "
+    - 98
+  20: !!python/object:mt940.tags.TransactionReferenceNumber
+    re: !!python/object/apply:re._compile
+    - (?P<transaction_reference>.{0,16})
+    - 98
+  21: !!python/object:mt940.tags.RelatedReference
+    re: !!python/object/apply:re._compile
+    - (?P<related_reference>.{0,16})
+    - 98
+  25: !!python/object:mt940.tags.AccountIdentification
+    re: !!python/object/apply:re._compile
+    - (?P<account_identification>.{0,35})
+    - 98
+  28: !!python/object:mt940.tags.StatementNumber
+    re: !!python/object/apply:re._compile
+    - "\n    (?P<statement_number>\\d{1,5})  # 5n\n    (?:/?(?P<sequence_number>\\\
+      d{1,5}))?  # [/5n]\n    $"
+    - 98
+  60: !!python/object:mt940.tags.OpeningBalance
+    re: &id001 !!python/object/apply:re._compile
+    - "^\n    (?P<status>[DC])  # 1!a Debit/Credit\n    (?P<year>\\d{2})  # 6!n Value\
+      \ Date (YYMMDD)\n    (?P<month>\\d{2})\n    (?P<day>\\d{2})\n    (?P<currency>.{3})\
+      \  # 3!a Currency\n    (?P<amount>[0-9,]{0,16})  # 15d Amount (includes decimal\
+      \ sign, so 16)\n    "
+    - 98
+  60M: !!python/object:mt940.tags.IntermediateOpeningBalance
+    re: *id001
+  60F: !!python/object:mt940.tags.FinalOpeningBalance
+    re: *id001
+  61: !!python/object:mt940.tags.Statement
+    re: !!python/object/apply:re._compile
+    - "^\n    (?P<year>\\d{2})  # 6!n Value Date (YYMMDD)\n    (?P<month>\\d{2})\n\
+      \    (?P<day>\\d{2})\n    (?P<entry_month>\\d{2}|\\s{2})?  # [4!n] Entry Date\
+      \ (MMDD)\n    (?P<entry_day>\\d{2}|\\s{2})?\n    (?P<status>R?[DC])  # 2a Debit/Credit\
+      \ Mark\n    (?P<funds_code>[A-Z])? # [1!a] Funds Code (3rd character of the\
+      \ currency\n                            # code, if needed)\n    [\\n ]?\n  \
+      \  (?P<amount>[\\d,]{1,15})  # 15d Amount\n    (?P<id>[A-Z][A-Z0-9 ]{3})?\n\
+      \    (?P<customer_reference>((?!//)[^\\n]){0,16})\n    (//(?P<bank_reference>.{0,23}))?\n\
+      \    # Supplementary details: the SWIFT spec caps this at 34x, but some banks\n\
+      \    # (e.g. Wise, issue #117) send more, so the length limit is relaxed. This\n\
+      \    # only ever turns a previous parse error into a successful parse.\n   \
+      \ (\\n?(?P<extra_details>.*))?\n    $"
+    - 98
+  62: !!python/object:mt940.tags.ClosingBalance
+    re: *id001
+  62M: !!python/object:mt940.tags.IntermediateClosingBalance
+    re: *id001
+  62F: !!python/object:mt940.tags.FinalClosingBalance
+    re: *id001
+  64: !!python/object:mt940.tags.AvailableBalance
+    re: *id001
+  65: !!python/object:mt940.tags.ForwardAvailableBalance
+    re: *id001
+  86: !!python/object:mt940.tags.TransactionDetails
+    re: !!python/object/apply:re._compile
+    - "\n    (?P<transaction_details>[\\s\\S]*)\n    "
+    - 98
+  34: !!python/object:mt940.tags.FloorLimitIndicator
+    re: !!python/object/apply:re._compile
+    - "^\n    (?P<currency>[A-Z]{3})  # 3!a Currency\n    (?P<status>[DC ]?)  # 2a\
+      \ Debit/Credit Mark\n    (?P<amount>[0-9,]{0,16})  # 15d Amount (includes decimal\
+      \ sign, so 16)\n    $"
+    - 98
+  NS: !!python/object:mt940.tags.NonSwift
+    re: !!python/object/apply:re._compile
+    - "\n    (?P<non_swift>[\\s\\S]*)\n    $"
+    - 98
+  90: !!python/object:mt940.tags.SumEntries
+    re: &id002 !!python/object/apply:re._compile
+    - "^\n    (?P<number>\\d*)\n    (?P<currency>.{3})  # 3!a Currency\n    (?P<amount>[\\\
+      d,]{1,15})  # 15d Amount\n    "
+    - 98
+  90D: !!python/object:mt940.tags.SumDebitEntries
+    re: *id002
+  90C: !!python/object:mt940.tags.SumCreditEntries
+    re: *id002
+transaction_boundary: !!python/object/apply:builtins.frozenset
+- []
+transactions:
+- !!python/object:mt940.models.Transaction
+  data:
+    FRST_ONE_OFF_RECC: null
+    additional_position_date: null
+    additional_position_reference: BYA12345678901
+    additional_purpose: '000000012345 BIC: BYLADEMMABWA: Finanzamt Muenchen ABWA+Finanzamt
+      Sentinel'
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '-233.15'
+      currency: EUR
+    applicant_bin: BYLADEMM
+    applicant_creditor_id: 'DE99ZZZ00000012345 '
+    applicant_iban: DE99700500000000012345
+    applicant_name: Finanzamt Muenchen Abteilung Erhebung
+    bank_reference: null
+    compensation_amount: null
+    currency: EUR
+    customer_reference: ''
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B+EJDg==
+    debitor_identifier: null
+    deviate_applicant: null
+    deviate_recipient: null
+    end_to_end_reference: '123/123/12345-----L1101234567890123 '
+    extra_details: ''
+    funds_code: null
+    gvc_applicant_bin: null
+    gvc_applicant_iban: null
+    id: NMSC
+    old_SEPA_CI: null
+    old_SEPA_additional_position_reference: null
+    original_amount: null
+    posting_text: Basislastschrift
+    prima_nota: '931'
+    purpose: 'STEUERNR 123/123/12345     KOERPST 3VJ.17  233,15EUR EREF: 123/123/12345-----L1112345678912345
+      MREF: BYA12345678901 CRED: DE99ZZZ00000012345 IBAN: DE00700500'
+    purpose_code: null
+    recipient_name: null
+    return_debit_notes: '992'
+    settlement_tag: null
+    status: D
+    transaction_code: '105'
+    transaction_reference: STARTUMS
+  transactions: *id003

--- a/mt940_tests/self-provided/malformed_details.yml
+++ b/mt940_tests/self-provided/malformed_details.yml
@@ -22,6 +22,18 @@ data:
   sequence_number: null
   statement_number: '0'
   transaction_reference: STARTUMS
+options: !!python/object/new:mt940.options.Options
+  state:
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
 tags:
   13: !!python/object:mt940.tags.DateTimeIndication
     re: !!python/object/apply:re._compile
@@ -120,12 +132,11 @@ transactions:
       currency: EUR
     applicant_bin: BYLADEMM
     applicant_creditor_id: 'DE99ZZZ00000012345 '
-    applicant_iban: DE99700500000000012345
-    applicant_name: Finanzamt Muenchen Abteilung Erhebung
+    applicant_name: DE99700500000000012345Finanzamt Muenchen Abteilung Erhebung
     bank_reference: null
     compensation_amount: null
     currency: EUR
-    customer_reference: ''
+    customer_reference: null
     date: !!python/object/apply:mt940.models.Date
     - !!binary |
       B+EJDg==

--- a/mt940_tests/self-provided/mt942.yml
+++ b/mt940_tests/self-provided/mt942.yml
@@ -14,7 +14,7 @@ data:
     B+AKHhEeAAAAAA==
   - !!python/object/apply:mt940.models.FixedOffset
     state:
-      _name: '0'
+      _name: '0000'
       _offset: !!python/object/apply:datetime.timedelta
       - 0
       - 0
@@ -27,6 +27,18 @@ data:
     currency: EUR
     number: '1'
   transaction_reference: CGNGHKLI0290980
+options: !!python/object/new:mt940.options.Options
+  state:
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
 tags:
   13: !!python/object:mt940.tags.DateTimeIndication
     re: !!python/object/apply:re._compile

--- a/mt940_tests/self-provided/multiline.all.yml
+++ b/mt940_tests/self-provided/multiline.all.yml
@@ -1,0 +1,197 @@
+&id004 !!python/object:mt940.models.Transactions
+data:
+  account_identification: 'BILLLULLXXX/"NUMERO DE COMPTE IBAN '
+  available_balance: !!python/object:mt940.models.Balance
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '11.40'
+      currency: EUR
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9QIBA==
+    status: C
+  final_closing_balance: !!python/object:mt940.models.Balance
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '11.40'
+      currency: EUR
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9QIBA==
+    status: C
+  final_opening_balance: !!python/object:mt940.models.Balance
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '16.40'
+      currency: EUR
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9QIAg==
+    status: C
+  sequence_number: '001'
+  statement_number: '00115'
+  transaction_reference: BILMT940
+options: !!python/object/new:mt940.options.Options
+  state:
+  - true
+  - true
+  - true
+  - true
+  - true
+  - true
+  - true
+  - true
+  - true
+  - true
+tags:
+  13: !!python/object:mt940.tags.DateTimeIndication
+    re: !!python/object/apply:re._compile
+    - "^\n    (?P<year>\\d{2})\n    (?P<month>\\d{2})\n    (?P<day>\\d{2})\n    (?P<hour>\\\
+      d{2})\n    (?P<minute>\\d{2})\n    ((?P<offset_sign>[+-])(?P<offset>\\d{4}))?\n\
+      \    "
+    - 98
+  20: !!python/object:mt940.tags.TransactionReferenceNumber
+    re: !!python/object/apply:re._compile
+    - (?P<transaction_reference>.{0,16})
+    - 98
+  21: !!python/object:mt940.tags.RelatedReference
+    re: !!python/object/apply:re._compile
+    - (?P<related_reference>.{0,16})
+    - 98
+  25: !!python/object:mt940.tags.AccountIdentification
+    re: !!python/object/apply:re._compile
+    - (?P<account_identification>.{0,35})
+    - 98
+  28: !!python/object:mt940.tags.StatementNumber
+    re: !!python/object/apply:re._compile
+    - "\n    (?P<statement_number>\\d{1,5})  # 5n\n    (?:/?(?P<sequence_number>\\\
+      d{1,5}))?  # [/5n]\n    $"
+    - 98
+  60: !!python/object:mt940.tags.OpeningBalance
+    re: &id001 !!python/object/apply:re._compile
+    - "^\n    (?P<status>[DC])  # 1!a Debit/Credit\n    (?P<year>\\d{2})  # 6!n Value\
+      \ Date (YYMMDD)\n    (?P<month>\\d{2})\n    (?P<day>\\d{2})\n    (?P<currency>.{3})\
+      \  # 3!a Currency\n    (?P<amount>[0-9,]{0,16})  # 15d Amount (includes decimal\
+      \ sign, so 16)\n    "
+    - 98
+  60M: !!python/object:mt940.tags.IntermediateOpeningBalance
+    re: *id001
+  60F: !!python/object:mt940.tags.FinalOpeningBalance
+    re: *id001
+  61: !!python/object:mt940.tags.Statement
+    re: !!python/object/apply:re._compile
+    - "^\n    (?P<year>\\d{2})  # 6!n Value Date (YYMMDD)\n    (?P<month>\\d{2})\n\
+      \    (?P<day>\\d{2})\n    (?P<entry_month>\\d{2}|\\s{2})?  # [4!n] Entry Date\
+      \ (MMDD)\n    (?P<entry_day>\\d{2}|\\s{2})?\n    (?P<status>R?[DC])  # 2a Debit/Credit\
+      \ Mark\n    (?P<funds_code>[A-Z])? # [1!a] Funds Code (3rd character of the\
+      \ currency\n                            # code, if needed)\n    [\\n ]?\n  \
+      \  (?P<amount>[\\d,]{1,15})  # 15d Amount\n    (?P<id>[A-Z][A-Z0-9 ]{3})?\n\
+      \    (?P<customer_reference>((?!//)[^\\n]){0,16})\n    (//(?P<bank_reference>.{0,23}))?\n\
+      \    # Supplementary details: the SWIFT spec caps this at 34x, but some banks\n\
+      \    # (e.g. Wise, issue #117) send more, so the length limit is relaxed. This\n\
+      \    # only ever turns a previous parse error into a successful parse.\n   \
+      \ (\\n?(?P<extra_details>.*))?\n    $"
+    - 98
+  62: !!python/object:mt940.tags.ClosingBalance
+    re: *id001
+  62M: !!python/object:mt940.tags.IntermediateClosingBalance
+    re: *id001
+  62F: !!python/object:mt940.tags.FinalClosingBalance
+    re: *id001
+  64: !!python/object:mt940.tags.AvailableBalance
+    re: *id001
+  65: !!python/object:mt940.tags.ForwardAvailableBalance
+    re: *id001
+  86: !!python/object:mt940.tags.TransactionDetails
+    re: !!python/object/apply:re._compile
+    - "\n    (?P<transaction_details>[\\s\\S]*)\n    "
+    - 98
+  34: !!python/object:mt940.tags.FloorLimitIndicator
+    re: !!python/object/apply:re._compile
+    - "^\n    (?P<currency>[A-Z]{3})  # 3!a Currency\n    (?P<status>[DC ]?)  # 2a\
+      \ Debit/Credit Mark\n    (?P<amount>[0-9,]{0,16})  # 15d Amount (includes decimal\
+      \ sign, so 16)\n    $"
+    - 98
+  NS: !!python/object:mt940.tags.NonSwift
+    re: !!python/object/apply:re._compile
+    - "\n    (?P<non_swift>[\\s\\S]*)\n    $"
+    - 98
+  90: !!python/object:mt940.tags.SumEntries
+    re: &id002 !!python/object/apply:re._compile
+    - "^\n    (?P<number>\\d*)\n    (?P<currency>.{3})  # 3!a Currency\n    (?P<amount>[\\\
+      d,]{1,15})  # 15d Amount\n    "
+    - 98
+  90D: !!python/object:mt940.tags.SumDebitEntries
+    re: *id002
+  90C: !!python/object:mt940.tags.SumCreditEntries
+    re: *id002
+transaction_boundary: !!python/object/apply:builtins.frozenset
+- []
+transactions:
+- !!python/object:mt940.models.Transaction
+  data:
+    additional_purpose: NOM ET ADRESSE DO / BENEF 112345678NOM ET ADRESSE DO / BENEF
+      212345678NOM ET ADRESSE DO / BENEF 312345678NOM ET ADRESSE DO / BENEF 412345678NOM
+      ET ADRESSE DO / BENEF 512345678NOM ET ADRESSE DO / BENEF 612345678
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '-5'
+      currency: EUR
+    applicant_bin: BILLLULL1234
+    applicant_iban: NUMERO DE COMPTE01234567
+    applicant_name: NOM DU DO / BENEFICIAIRE 11NOM DU DO / BENEFICIAIRE 22
+    bank_reference: MUL0408041114005
+    currency: EUR
+    customer_reference: REFERENCE DO 111
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9QIBA==
+    entry_date: &id003 !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9QIBA==
+    extra_details: /OCMT/EUR4,5//IACC/D3/
+    funds_code: R
+    guessed_entry_date: *id003
+    id: NTRF
+    posting_text: VIREMENT111111111111111111X
+    prima_nota: null
+    purpose: LIGNE111111111111111111111X12345678LIGNE222222222222222222222X12345678LIGNE333333333333333333333X12345678LIGNE444444444444444444444X12345678LIGNE555555555555555555555X12345678/CHGS/EUR0,5/LIGNE777777777777777777777X12345678LIGNE888888888888888888888X12345678LIGNE999999999999999999999X12345678LIGNE101010101010101010101X12345678
+    recipient_name: null
+    return_debit_notes: null
+    status: D
+    transaction_code: '020'
+    transaction_details: 'FREE TEXT
+
+      FREE TEXT
+
+      FREE TEXT
+
+      FREE TEXT
+
+      FREE TEXT
+
+      FREE TEXT'
+    transaction_reference: BILMT940
+  transactions: *id004
+- !!python/object:mt940.models.Transaction
+  data:
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '119'
+      currency: EUR
+    bank_reference: O/341241774
+    currency: EUR
+    customer_reference: 341241773/1XXXXX
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B+YMEw==
+    entry_date: &id005 !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B+YMFA==
+    extra_details: Paiement
+    funds_code: null
+    guessed_entry_date: *id005
+    id: NMSC
+    status: C
+    transaction_reference: BILMT940
+  transactions: *id004

--- a/mt940_tests/self-provided/multiline.yml
+++ b/mt940_tests/self-provided/multiline.yml
@@ -31,6 +31,18 @@ data:
   sequence_number: '001'
   statement_number: '00115'
   transaction_reference: BILMT940
+options: !!python/object/new:mt940.options.Options
+  state:
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
 tags:
   13: !!python/object:mt940.tags.DateTimeIndication
     re: !!python/object/apply:re._compile
@@ -118,16 +130,14 @@ transaction_boundary: !!python/object/apply:builtins.frozenset
 transactions:
 - !!python/object:mt940.models.Transaction
   data:
-    additional_purpose: NOM ET ADRESSE DO / BENEF 112345678NOM ET ADRESSE DO / BENEF
-      212345678NOM ET ADRESSE DO / BENEF 312345678NOM ET ADRESSE DO / BENEF 412345678NOM
-      ET ADRESSE DO / BENEF 512345678NOM ET ADRESSE DO / BENEF 612345678
+    additional_purpose: NOM ET ADRESSE DO / BENEF 112345678
     amount: !!python/object:mt940.models.Amount
       amount: !!python/object/apply:decimal.Decimal
       - '-5'
       currency: EUR
     applicant_bin: BILLLULL1234
-    applicant_iban: NUMERO DE COMPTE01234567
-    applicant_name: NOM DU DO / BENEFICIAIRE 11NOM DU DO / BENEFICIAIRE 22
+    applicant_name: NUMERO DE COMPTE01234567NOM DU DO / BENEFICIAIRE 11NOM DU DO /
+      BENEFICIAIRE 22
     bank_reference: MUL0408041114005
     currency: EUR
     customer_reference: REFERENCE DO 111

--- a/mt940_tests/self-provided/overly_long_details.all.yml
+++ b/mt940_tests/self-provided/overly_long_details.all.yml
@@ -1,0 +1,167 @@
+&id003 !!python/object:mt940.models.Transactions
+data:
+  account_identification: 12345678/1020304050
+  final_closing_balance: !!python/object:mt940.models.Balance
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '12345.98'
+      currency: EUR
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B+EJDg==
+    status: C
+  final_opening_balance: !!python/object:mt940.models.Balance
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '12345.12'
+      currency: EUR
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B+EJDg==
+    status: C
+  sequence_number: null
+  statement_number: '0'
+  transaction_reference: STARTUMS
+options: !!python/object/new:mt940.options.Options
+  state:
+  - true
+  - true
+  - true
+  - true
+  - true
+  - true
+  - true
+  - true
+  - true
+  - true
+tags:
+  13: !!python/object:mt940.tags.DateTimeIndication
+    re: !!python/object/apply:re._compile
+    - "^\n    (?P<year>\\d{2})\n    (?P<month>\\d{2})\n    (?P<day>\\d{2})\n    (?P<hour>\\\
+      d{2})\n    (?P<minute>\\d{2})\n    ((?P<offset_sign>[+-])(?P<offset>\\d{4}))?\n\
+      \    "
+    - 98
+  20: !!python/object:mt940.tags.TransactionReferenceNumber
+    re: !!python/object/apply:re._compile
+    - (?P<transaction_reference>.{0,16})
+    - 98
+  21: !!python/object:mt940.tags.RelatedReference
+    re: !!python/object/apply:re._compile
+    - (?P<related_reference>.{0,16})
+    - 98
+  25: !!python/object:mt940.tags.AccountIdentification
+    re: !!python/object/apply:re._compile
+    - (?P<account_identification>.{0,35})
+    - 98
+  28: !!python/object:mt940.tags.StatementNumber
+    re: !!python/object/apply:re._compile
+    - "\n    (?P<statement_number>\\d{1,5})  # 5n\n    (?:/?(?P<sequence_number>\\\
+      d{1,5}))?  # [/5n]\n    $"
+    - 98
+  60: !!python/object:mt940.tags.OpeningBalance
+    re: &id001 !!python/object/apply:re._compile
+    - "^\n    (?P<status>[DC])  # 1!a Debit/Credit\n    (?P<year>\\d{2})  # 6!n Value\
+      \ Date (YYMMDD)\n    (?P<month>\\d{2})\n    (?P<day>\\d{2})\n    (?P<currency>.{3})\
+      \  # 3!a Currency\n    (?P<amount>[0-9,]{0,16})  # 15d Amount (includes decimal\
+      \ sign, so 16)\n    "
+    - 98
+  60M: !!python/object:mt940.tags.IntermediateOpeningBalance
+    re: *id001
+  60F: !!python/object:mt940.tags.FinalOpeningBalance
+    re: *id001
+  61: !!python/object:mt940.tags.Statement
+    re: !!python/object/apply:re._compile
+    - "^\n    (?P<year>\\d{2})  # 6!n Value Date (YYMMDD)\n    (?P<month>\\d{2})\n\
+      \    (?P<day>\\d{2})\n    (?P<entry_month>\\d{2}|\\s{2})?  # [4!n] Entry Date\
+      \ (MMDD)\n    (?P<entry_day>\\d{2}|\\s{2})?\n    (?P<status>R?[DC])  # 2a Debit/Credit\
+      \ Mark\n    (?P<funds_code>[A-Z])? # [1!a] Funds Code (3rd character of the\
+      \ currency\n                            # code, if needed)\n    [\\n ]?\n  \
+      \  (?P<amount>[\\d,]{1,15})  # 15d Amount\n    (?P<id>[A-Z][A-Z0-9 ]{3})?\n\
+      \    (?P<customer_reference>((?!//)[^\\n]){0,16})\n    (//(?P<bank_reference>.{0,23}))?\n\
+      \    # Supplementary details: the SWIFT spec caps this at 34x, but some banks\n\
+      \    # (e.g. Wise, issue #117) send more, so the length limit is relaxed. This\n\
+      \    # only ever turns a previous parse error into a successful parse.\n   \
+      \ (\\n?(?P<extra_details>.*))?\n    $"
+    - 98
+  62: !!python/object:mt940.tags.ClosingBalance
+    re: *id001
+  62M: !!python/object:mt940.tags.IntermediateClosingBalance
+    re: *id001
+  62F: !!python/object:mt940.tags.FinalClosingBalance
+    re: *id001
+  64: !!python/object:mt940.tags.AvailableBalance
+    re: *id001
+  65: !!python/object:mt940.tags.ForwardAvailableBalance
+    re: *id001
+  86: !!python/object:mt940.tags.TransactionDetails
+    re: !!python/object/apply:re._compile
+    - "\n    (?P<transaction_details>[\\s\\S]*)\n    "
+    - 98
+  34: !!python/object:mt940.tags.FloorLimitIndicator
+    re: !!python/object/apply:re._compile
+    - "^\n    (?P<currency>[A-Z]{3})  # 3!a Currency\n    (?P<status>[DC ]?)  # 2a\
+      \ Debit/Credit Mark\n    (?P<amount>[0-9,]{0,16})  # 15d Amount (includes decimal\
+      \ sign, so 16)\n    $"
+    - 98
+  NS: !!python/object:mt940.tags.NonSwift
+    re: !!python/object/apply:re._compile
+    - "\n    (?P<non_swift>[\\s\\S]*)\n    $"
+    - 98
+  90: !!python/object:mt940.tags.SumEntries
+    re: &id002 !!python/object/apply:re._compile
+    - "^\n    (?P<number>\\d*)\n    (?P<currency>.{3})  # 3!a Currency\n    (?P<amount>[\\\
+      d,]{1,15})  # 15d Amount\n    "
+    - 98
+  90D: !!python/object:mt940.tags.SumDebitEntries
+    re: *id002
+  90C: !!python/object:mt940.tags.SumCreditEntries
+    re: *id002
+transaction_boundary: !!python/object/apply:builtins.frozenset
+- []
+transactions:
+- !!python/object:mt940.models.Transaction
+  data:
+    FRST_ONE_OFF_RECC: null
+    additional_position_date: null
+    additional_position_reference: BYA12345678901
+    additional_purpose: '000000012345 BIC: BYLADEMMABWA: Finanzamt Muenchen ABWA+Finanzamt
+      Sentinel'
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '-233.15'
+      currency: EUR
+    applicant_bin: BYLADEMM
+    applicant_creditor_id: 'DE99ZZZ00000012345 '
+    applicant_iban: DE99700500000000012345
+    applicant_name: Finanzamt Muenchen Abteilung Erhebung
+    bank_reference: null
+    compensation_amount: null
+    currency: EUR
+    customer_reference: ''
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B+EJDg==
+    debitor_identifier: null
+    deviate_applicant: null
+    deviate_recipient: null
+    end_to_end_reference: '123/123/12345-----L1101234567890123 '
+    extra_details: ''
+    funds_code: null
+    gvc_applicant_bin: null
+    gvc_applicant_iban: null
+    id: NMSC
+    old_SEPA_CI: null
+    old_SEPA_additional_position_reference: null
+    original_amount: null
+    posting_text: Basislastschrift
+    prima_nota: '931'
+    purpose: 'STEUERNR 123/123/12345     KOERPST 3VJ.17  233,15EUR EREF: 123/123/12345-----L1112345678912345
+      MREF: BYA12345678901 CRED: DE99ZZZ00000012345 IBAN: DE00700500'
+    purpose_code: null
+    recipient_name: null
+    return_debit_notes: '992'
+    settlement_tag: null
+    status: D
+    transaction_code: '105'
+    transaction_reference: STARTUMS
+  transactions: *id003

--- a/mt940_tests/self-provided/overly_long_details.yml
+++ b/mt940_tests/self-provided/overly_long_details.yml
@@ -22,6 +22,18 @@ data:
   sequence_number: null
   statement_number: '0'
   transaction_reference: STARTUMS
+options: !!python/object/new:mt940.options.Options
+  state:
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
 tags:
   13: !!python/object:mt940.tags.DateTimeIndication
     re: !!python/object/apply:re._compile
@@ -120,12 +132,11 @@ transactions:
       currency: EUR
     applicant_bin: BYLADEMM
     applicant_creditor_id: 'DE99ZZZ00000012345 '
-    applicant_iban: DE99700500000000012345
-    applicant_name: Finanzamt Muenchen Abteilung Erhebung
+    applicant_name: DE99700500000000012345Finanzamt Muenchen Abteilung Erhebung
     bank_reference: null
     compensation_amount: null
     currency: EUR
-    customer_reference: ''
+    customer_reference: null
     date: !!python/object/apply:mt940.models.Date
     - !!binary |
       B+EJDg==

--- a/mt940_tests/self-provided/raiffeisen-cmi.yml
+++ b/mt940_tests/self-provided/raiffeisen-cmi.yml
@@ -40,6 +40,18 @@ data:
   sequence_number: null
   statement_number: '0072'
   transaction_reference: STARTUMS
+options: !!python/object/new:mt940.options.Options
+  state:
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
 tags:
   13: !!python/object:mt940.tags.DateTimeIndication
     re: !!python/object/apply:re._compile

--- a/mt940_tests/self-provided/raphaelm.all.yml
+++ b/mt940_tests/self-provided/raphaelm.all.yml
@@ -1,0 +1,386 @@
+&id004 !!python/object:mt940.models.Transactions
+data:
+  account_identification: '3346780111'
+  final_closing_balance: !!python/object:mt940.models.Balance
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '0.00'
+      currency: '950'
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9IDGA==
+    status: C
+  final_opening_balance: !!python/object:mt940.models.Balance
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '145000.00'
+      currency: DEM
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9IDGA==
+    status: C
+  intermediate_closing_balance: !!python/object:mt940.models.Balance
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '0.00'
+      currency: '105'
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9IDDw==
+    status: C
+  intermediate_opening_balance: !!python/object:mt940.models.Balance
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '105000.00'
+      currency: DEM
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9IDDw==
+    status: C
+  non_swift: '22Test GmbH
+
+    23Testkonto
+
+    240,800
+
+    25010102311202
+
+    3037010000
+
+    3190000022
+
+    32
+
+    33
+
+    34LEER'
+  non_swift_22: Test GmbH
+  non_swift_23: Testkonto
+  non_swift_24: 0,800
+  non_swift_25: '010102311202'
+  non_swift_30: '37010000'
+  non_swift_31: '90000022'
+  non_swift_34: LEER
+  non_swift_text: 'Test GmbH
+
+    Testkonto
+
+    0,800
+
+    010102311202
+
+    37010000
+
+    90000022
+
+    32
+
+    33
+
+    LEER'
+  sequence_number: '1'
+  statement_number: '2'
+  transaction_reference: STARTUMS
+options: !!python/object/new:mt940.options.Options
+  state:
+  - true
+  - true
+  - true
+  - true
+  - true
+  - true
+  - true
+  - true
+  - true
+  - true
+tags:
+  13: !!python/object:mt940.tags.DateTimeIndication
+    re: !!python/object/apply:re._compile
+    - "^\n    (?P<year>\\d{2})\n    (?P<month>\\d{2})\n    (?P<day>\\d{2})\n    (?P<hour>\\\
+      d{2})\n    (?P<minute>\\d{2})\n    ((?P<offset_sign>[+-])(?P<offset>\\d{4}))?\n\
+      \    "
+    - 98
+  20: !!python/object:mt940.tags.TransactionReferenceNumber
+    re: !!python/object/apply:re._compile
+    - (?P<transaction_reference>.{0,16})
+    - 98
+  21: !!python/object:mt940.tags.RelatedReference
+    re: !!python/object/apply:re._compile
+    - (?P<related_reference>.{0,16})
+    - 98
+  25: !!python/object:mt940.tags.AccountIdentification
+    re: !!python/object/apply:re._compile
+    - (?P<account_identification>.{0,35})
+    - 98
+  28: !!python/object:mt940.tags.StatementNumber
+    re: !!python/object/apply:re._compile
+    - "\n    (?P<statement_number>\\d{1,5})  # 5n\n    (?:/?(?P<sequence_number>\\\
+      d{1,5}))?  # [/5n]\n    $"
+    - 98
+  60: !!python/object:mt940.tags.OpeningBalance
+    re: &id001 !!python/object/apply:re._compile
+    - "^\n    (?P<status>[DC])  # 1!a Debit/Credit\n    (?P<year>\\d{2})  # 6!n Value\
+      \ Date (YYMMDD)\n    (?P<month>\\d{2})\n    (?P<day>\\d{2})\n    (?P<currency>.{3})\
+      \  # 3!a Currency\n    (?P<amount>[0-9,]{0,16})  # 15d Amount (includes decimal\
+      \ sign, so 16)\n    "
+    - 98
+  60M: !!python/object:mt940.tags.IntermediateOpeningBalance
+    re: *id001
+  60F: !!python/object:mt940.tags.FinalOpeningBalance
+    re: *id001
+  61: !!python/object:mt940.tags.Statement
+    re: !!python/object/apply:re._compile
+    - "^\n    (?P<year>\\d{2})  # 6!n Value Date (YYMMDD)\n    (?P<month>\\d{2})\n\
+      \    (?P<day>\\d{2})\n    (?P<entry_month>\\d{2}|\\s{2})?  # [4!n] Entry Date\
+      \ (MMDD)\n    (?P<entry_day>\\d{2}|\\s{2})?\n    (?P<status>R?[DC])  # 2a Debit/Credit\
+      \ Mark\n    (?P<funds_code>[A-Z])? # [1!a] Funds Code (3rd character of the\
+      \ currency\n                            # code, if needed)\n    [\\n ]?\n  \
+      \  (?P<amount>[\\d,]{1,15})  # 15d Amount\n    (?P<id>[A-Z][A-Z0-9 ]{3})?\n\
+      \    (?P<customer_reference>((?!//)[^\\n]){0,16})\n    (//(?P<bank_reference>.{0,23}))?\n\
+      \    # Supplementary details: the SWIFT spec caps this at 34x, but some banks\n\
+      \    # (e.g. Wise, issue #117) send more, so the length limit is relaxed. This\n\
+      \    # only ever turns a previous parse error into a successful parse.\n   \
+      \ (\\n?(?P<extra_details>.*))?\n    $"
+    - 98
+  62: !!python/object:mt940.tags.ClosingBalance
+    re: *id001
+  62M: !!python/object:mt940.tags.IntermediateClosingBalance
+    re: *id001
+  62F: !!python/object:mt940.tags.FinalClosingBalance
+    re: *id001
+  64: !!python/object:mt940.tags.AvailableBalance
+    re: *id001
+  65: !!python/object:mt940.tags.ForwardAvailableBalance
+    re: *id001
+  86: !!python/object:mt940.tags.TransactionDetails
+    re: !!python/object/apply:re._compile
+    - "\n    (?P<transaction_details>[\\s\\S]*)\n    "
+    - 98
+  34: !!python/object:mt940.tags.FloorLimitIndicator
+    re: !!python/object/apply:re._compile
+    - "^\n    (?P<currency>[A-Z]{3})  # 3!a Currency\n    (?P<status>[DC ]?)  # 2a\
+      \ Debit/Credit Mark\n    (?P<amount>[0-9,]{0,16})  # 15d Amount (includes decimal\
+      \ sign, so 16)\n    $"
+    - 98
+  NS: !!python/object:mt940.tags.NonSwift
+    re: !!python/object/apply:re._compile
+    - "\n    (?P<non_swift>[\\s\\S]*)\n    $"
+    - 98
+  90: !!python/object:mt940.tags.SumEntries
+    re: &id002 !!python/object/apply:re._compile
+    - "^\n    (?P<number>\\d*)\n    (?P<currency>.{3})  # 3!a Currency\n    (?P<amount>[\\\
+      d,]{1,15})  # 15d Amount\n    "
+    - 98
+  90D: !!python/object:mt940.tags.SumDebitEntries
+    re: *id002
+  90C: !!python/object:mt940.tags.SumCreditEntries
+    re: *id002
+transaction_boundary: !!python/object/apply:builtins.frozenset
+- []
+transactions:
+- !!python/object:mt940.models.Transaction
+  data:
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '5000.00'
+      currency: DEM
+    bank_reference: null
+    currency: DEM
+    customer_reference: '68790452'
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9IDEQ==
+    entry_date: &id003 !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9IDFA==
+    extra_details: ''
+    funds_code: M
+    guessed_entry_date: *id003
+    id: S051
+    non_swift: "01Verwendungszweck 1\n02Verwendungszweck 2\n15Empf\xE4nger\n17Buchungstext\n\
+      1812345\n191000\n204711"
+    non_swift_01: Verwendungszweck 1
+    non_swift_02: Verwendungszweck 2
+    non_swift_15: "Empf\xE4nger"
+    non_swift_17: Buchungstext
+    non_swift_18: '12345'
+    non_swift_19: '1000'
+    non_swift_20: '4711'
+    non_swift_text: "Verwendungszweck 1\nVerwendungszweck 2\nEmpf\xE4nger\nBuchungstext\n\
+      12345\n1000\n4711"
+    status: C
+    transaction_reference: STARTUMS
+  transactions: *id004
+- !!python/object:mt940.models.Transaction
+  data:
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '20000.00'
+      currency: DEM
+    bank_reference: null
+    currency: DEM
+    customer_reference: ''
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9IDFg==
+    extra_details: ''
+    funds_code: M
+    id: NCHG
+    status: C
+    transaction_reference: STARTUMS
+  transactions: *id004
+- !!python/object:mt940.models.Transaction
+  data:
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '20000.00'
+      currency: DEM
+    bank_reference: null
+    currency: DEM
+    customer_reference: ''
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9IDFg==
+    extra_details: ''
+    funds_code: M
+    id: S051
+    status: C
+    transaction_reference: STARTUMS
+  transactions: *id004
+- !!python/object:mt940.models.Transaction
+  data:
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '20000.00'
+      currency: DEM
+    bank_reference: null
+    currency: DEM
+    customer_reference: ''
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9IDFg==
+    extra_details: ''
+    funds_code: M
+    id: S051
+    status: C
+    transaction_reference: STARTUMS
+  transactions: *id004
+- !!python/object:mt940.models.Transaction
+  data:
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '20000.00'
+      currency: DEM
+    bank_reference: null
+    currency: DEM
+    customer_reference: ''
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9IDFg==
+    extra_details: ''
+    funds_code: M
+    id: S051
+    status: C
+    transaction_reference: STARTUMS
+  transactions: *id004
+- !!python/object:mt940.models.Transaction
+  data:
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '20000.00'
+      currency: DEM
+    bank_reference: null
+    currency: DEM
+    customer_reference: ''
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9IDFg==
+    extra_details: ''
+    funds_code: M
+    id: S051
+    non_swift: '223037010000'
+    non_swift_22: '3037010000'
+    non_swift_text: '3037010000'
+    status: C
+    transaction_reference: STARTUMS
+  transactions: *id004
+- !!python/object:mt940.models.Transaction
+  data:
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '20000.00'
+      currency: DEM
+    bank_reference: null
+    currency: DEM
+    customer_reference: ''
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9IDFg==
+    extra_details: ''
+    funds_code: M
+    id: S051
+    status: C
+    transaction_reference: STARTUMS
+  transactions: *id004
+- !!python/object:mt940.models.Transaction
+  data:
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '20000.00'
+      currency: DEM
+    bank_reference: null
+    currency: DEM
+    customer_reference: ''
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9IDFg==
+    extra_details: ''
+    funds_code: M
+    id: S051
+    non_swift: '22Meyer + Schneider
+
+      23Testkonto
+
+      3037010000
+
+      3187132101'
+    non_swift_22: Meyer + Schneider
+    non_swift_23: Testkonto
+    non_swift_30: '37010000'
+    non_swift_31: '87132101'
+    non_swift_text: 'Meyer + Schneider
+
+      Testkonto
+
+      37010000
+
+      87132101'
+    status: C
+    transaction_reference: STARTUMS
+  transactions: *id004
+- !!python/object:mt940.models.Transaction
+  data:
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '-50000.00'
+      currency: DEM
+    bank_reference: null
+    currency: DEM
+    customer_reference: ''
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B9IDGA==
+    extra_details: ''
+    funds_code: M
+    id: S051
+    non_swift: '01bekannt
+
+      1812345'
+    non_swift_01: bekannt
+    non_swift_18: '12345'
+    non_swift_text: 'bekannt
+
+      12345'
+    status: D
+    transaction_reference: STARTUMS
+  transactions: *id004

--- a/mt940_tests/self-provided/raphaelm.yml
+++ b/mt940_tests/self-provided/raphaelm.yml
@@ -73,7 +73,6 @@ data:
 
     90000022
 
-    32
 
     33
 
@@ -81,6 +80,18 @@ data:
   sequence_number: '1'
   statement_number: '2'
   transaction_reference: STARTUMS
+options: !!python/object/new:mt940.options.Options
+  state:
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
 tags:
   13: !!python/object:mt940.tags.DateTimeIndication
     re: !!python/object/apply:re._compile

--- a/mt940_tests/self-provided/sparkassen.all.yml
+++ b/mt940_tests/self-provided/sparkassen.all.yml
@@ -1,0 +1,146 @@
+&id004 !!python/object:mt940.models.Transactions
+data: {}
+options: !!python/object/new:mt940.options.Options
+  state:
+  - true
+  - true
+  - true
+  - true
+  - true
+  - true
+  - true
+  - true
+  - true
+  - true
+tags:
+  13: !!python/object:mt940.tags.DateTimeIndication
+    re: !!python/object/apply:re._compile
+    - "^\n    (?P<year>\\d{2})\n    (?P<month>\\d{2})\n    (?P<day>\\d{2})\n    (?P<hour>\\\
+      d{2})\n    (?P<minute>\\d{2})\n    ((?P<offset_sign>[+-])(?P<offset>\\d{4}))?\n\
+      \    "
+    - 98
+  20: !!python/object:mt940.tags.TransactionReferenceNumber
+    re: !!python/object/apply:re._compile
+    - (?P<transaction_reference>.{0,16})
+    - 98
+  21: !!python/object:mt940.tags.RelatedReference
+    re: !!python/object/apply:re._compile
+    - (?P<related_reference>.{0,16})
+    - 98
+  25: !!python/object:mt940.tags.AccountIdentification
+    re: !!python/object/apply:re._compile
+    - (?P<account_identification>.{0,35})
+    - 98
+  28: !!python/object:mt940.tags.StatementNumber
+    re: !!python/object/apply:re._compile
+    - "\n    (?P<statement_number>\\d{1,5})  # 5n\n    (?:/?(?P<sequence_number>\\\
+      d{1,5}))?  # [/5n]\n    $"
+    - 98
+  60: !!python/object:mt940.tags.OpeningBalance
+    re: &id001 !!python/object/apply:re._compile
+    - "^\n    (?P<status>[DC])  # 1!a Debit/Credit\n    (?P<year>\\d{2})  # 6!n Value\
+      \ Date (YYMMDD)\n    (?P<month>\\d{2})\n    (?P<day>\\d{2})\n    (?P<currency>.{3})\
+      \  # 3!a Currency\n    (?P<amount>[0-9,]{0,16})  # 15d Amount (includes decimal\
+      \ sign, so 16)\n    "
+    - 98
+  60M: !!python/object:mt940.tags.IntermediateOpeningBalance
+    re: *id001
+  60F: !!python/object:mt940.tags.FinalOpeningBalance
+    re: *id001
+  61: !!python/object:mt940.tags.Statement
+    re: !!python/object/apply:re._compile
+    - "^\n    (?P<year>\\d{2})  # 6!n Value Date (YYMMDD)\n    (?P<month>\\d{2})\n\
+      \    (?P<day>\\d{2})\n    (?P<entry_month>\\d{2}|\\s{2})?  # [4!n] Entry Date\
+      \ (MMDD)\n    (?P<entry_day>\\d{2}|\\s{2})?\n    (?P<status>R?[DC])  # 2a Debit/Credit\
+      \ Mark\n    (?P<funds_code>[A-Z])? # [1!a] Funds Code (3rd character of the\
+      \ currency\n                            # code, if needed)\n    [\\n ]?\n  \
+      \  (?P<amount>[\\d,]{1,15})  # 15d Amount\n    (?P<id>[A-Z][A-Z0-9 ]{3})?\n\
+      \    (?P<customer_reference>((?!//)[^\\n]){0,16})\n    (//(?P<bank_reference>.{0,23}))?\n\
+      \    # Supplementary details: the SWIFT spec caps this at 34x, but some banks\n\
+      \    # (e.g. Wise, issue #117) send more, so the length limit is relaxed. This\n\
+      \    # only ever turns a previous parse error into a successful parse.\n   \
+      \ (\\n?(?P<extra_details>.*))?\n    $"
+    - 98
+  62: !!python/object:mt940.tags.ClosingBalance
+    re: *id001
+  62M: !!python/object:mt940.tags.IntermediateClosingBalance
+    re: *id001
+  62F: !!python/object:mt940.tags.FinalClosingBalance
+    re: *id001
+  64: !!python/object:mt940.tags.AvailableBalance
+    re: *id001
+  65: !!python/object:mt940.tags.ForwardAvailableBalance
+    re: *id001
+  86: !!python/object:mt940.tags.TransactionDetails
+    re: !!python/object/apply:re._compile
+    - "\n    (?P<transaction_details>[\\s\\S]*)\n    "
+    - 98
+  34: !!python/object:mt940.tags.FloorLimitIndicator
+    re: !!python/object/apply:re._compile
+    - "^\n    (?P<currency>[A-Z]{3})  # 3!a Currency\n    (?P<status>[DC ]?)  # 2a\
+      \ Debit/Credit Mark\n    (?P<amount>[0-9,]{0,16})  # 15d Amount (includes decimal\
+      \ sign, so 16)\n    $"
+    - 98
+  NS: !!python/object:mt940.tags.NonSwift
+    re: !!python/object/apply:re._compile
+    - "\n    (?P<non_swift>[\\s\\S]*)\n    $"
+    - 98
+  90: !!python/object:mt940.tags.SumEntries
+    re: &id002 !!python/object/apply:re._compile
+    - "^\n    (?P<number>\\d*)\n    (?P<currency>.{3})  # 3!a Currency\n    (?P<amount>[\\\
+      d,]{1,15})  # 15d Amount\n    "
+    - 98
+  90D: !!python/object:mt940.tags.SumDebitEntries
+    re: *id002
+  90C: !!python/object:mt940.tags.SumCreditEntries
+    re: *id002
+transaction_boundary: !!python/object/apply:builtins.frozenset
+- []
+transactions:
+- !!python/object:mt940.models.Transaction
+  data:
+    FRST_ONE_OFF_RECC: null
+    additional_position_date: null
+    additional_position_reference: null
+    additional_purpose: null
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '30.00'
+      currency: null
+    applicant_bin: null
+    applicant_creditor_id: null
+    applicant_iban: null
+    applicant_name: null
+    bank_reference: null
+    compensation_amount: null
+    currency: null
+    customer_reference: NONREF
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B+ILGg==
+    debitor_identifier: null
+    deviate_applicant: null
+    deviate_recipient: null
+    end_to_end_reference: null
+    entry_date: &id003 !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B+ILGg==
+    extra_details: ''
+    funds_code: R
+    guessed_entry_date: *id003
+    gvc_applicant_bin: null
+    gvc_applicant_iban: null
+    id: N062
+    old_SEPA_CI: null
+    old_SEPA_additional_position_reference: null
+    original_amount: null
+    posting_text: GUTSCHR. UEBERWEISUNG
+    prima_nota: null
+    purpose: Test
+    purpose_code: null
+    recipient_name: null
+    return_debit_notes: null
+    settlement_tag: null
+    status: C
+    transaction_code: '166'
+  transactions: *id004

--- a/mt940_tests/self-provided/sparkassen.yml
+++ b/mt940_tests/self-provided/sparkassen.yml
@@ -1,5 +1,17 @@
 &id004 !!python/object:mt940.models.Transactions
 data: {}
+options: !!python/object/new:mt940.options.Options
+  state:
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
 tags:
   13: !!python/object:mt940.tags.DateTimeIndication
     re: !!python/object/apply:re._compile
@@ -97,12 +109,11 @@ transactions:
       currency: null
     applicant_bin: null
     applicant_creditor_id: null
-    applicant_iban: null
     applicant_name: null
     bank_reference: null
     compensation_amount: null
     currency: null
-    customer_reference: NONREF
+    customer_reference: null
     date: !!python/object/apply:mt940.models.Date
     - !!binary |
       B+ILGg==

--- a/mt940_tests/self-provided/transaction_details_wrapped.all.yml
+++ b/mt940_tests/self-provided/transaction_details_wrapped.all.yml
@@ -1,0 +1,153 @@
+&id004 !!python/object:mt940.models.Transactions
+data:
+  account_identification: 12345678/1020304050
+  final_closing_balance: !!python/object:mt940.models.Balance
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '1194.00'
+      currency: EUR
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B+ADAQ==
+    status: C
+  final_opening_balance: !!python/object:mt940.models.Balance
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '1200.00'
+      currency: EUR
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B+ACHQ==
+    status: C
+  sequence_number: '001'
+  statement_number: '00000'
+  transaction_reference: STARTUMSE
+options: !!python/object/new:mt940.options.Options
+  state:
+  - true
+  - true
+  - true
+  - true
+  - true
+  - true
+  - true
+  - true
+  - true
+  - true
+tags:
+  13: !!python/object:mt940.tags.DateTimeIndication
+    re: !!python/object/apply:re._compile
+    - "^\n    (?P<year>\\d{2})\n    (?P<month>\\d{2})\n    (?P<day>\\d{2})\n    (?P<hour>\\\
+      d{2})\n    (?P<minute>\\d{2})\n    ((?P<offset_sign>[+-])(?P<offset>\\d{4}))?\n\
+      \    "
+    - 98
+  20: !!python/object:mt940.tags.TransactionReferenceNumber
+    re: !!python/object/apply:re._compile
+    - (?P<transaction_reference>.{0,16})
+    - 98
+  21: !!python/object:mt940.tags.RelatedReference
+    re: !!python/object/apply:re._compile
+    - (?P<related_reference>.{0,16})
+    - 98
+  25: !!python/object:mt940.tags.AccountIdentification
+    re: !!python/object/apply:re._compile
+    - (?P<account_identification>.{0,35})
+    - 98
+  28: !!python/object:mt940.tags.StatementNumber
+    re: !!python/object/apply:re._compile
+    - "\n    (?P<statement_number>\\d{1,5})  # 5n\n    (?:/?(?P<sequence_number>\\\
+      d{1,5}))?  # [/5n]\n    $"
+    - 98
+  60: !!python/object:mt940.tags.OpeningBalance
+    re: &id001 !!python/object/apply:re._compile
+    - "^\n    (?P<status>[DC])  # 1!a Debit/Credit\n    (?P<year>\\d{2})  # 6!n Value\
+      \ Date (YYMMDD)\n    (?P<month>\\d{2})\n    (?P<day>\\d{2})\n    (?P<currency>.{3})\
+      \  # 3!a Currency\n    (?P<amount>[0-9,]{0,16})  # 15d Amount (includes decimal\
+      \ sign, so 16)\n    "
+    - 98
+  60M: !!python/object:mt940.tags.IntermediateOpeningBalance
+    re: *id001
+  60F: !!python/object:mt940.tags.FinalOpeningBalance
+    re: *id001
+  61: !!python/object:mt940.tags.Statement
+    re: !!python/object/apply:re._compile
+    - "^\n    (?P<year>\\d{2})  # 6!n Value Date (YYMMDD)\n    (?P<month>\\d{2})\n\
+      \    (?P<day>\\d{2})\n    (?P<entry_month>\\d{2}|\\s{2})?  # [4!n] Entry Date\
+      \ (MMDD)\n    (?P<entry_day>\\d{2}|\\s{2})?\n    (?P<status>R?[DC])  # 2a Debit/Credit\
+      \ Mark\n    (?P<funds_code>[A-Z])? # [1!a] Funds Code (3rd character of the\
+      \ currency\n                            # code, if needed)\n    [\\n ]?\n  \
+      \  (?P<amount>[\\d,]{1,15})  # 15d Amount\n    (?P<id>[A-Z][A-Z0-9 ]{3})?\n\
+      \    (?P<customer_reference>((?!//)[^\\n]){0,16})\n    (//(?P<bank_reference>.{0,23}))?\n\
+      \    # Supplementary details: the SWIFT spec caps this at 34x, but some banks\n\
+      \    # (e.g. Wise, issue #117) send more, so the length limit is relaxed. This\n\
+      \    # only ever turns a previous parse error into a successful parse.\n   \
+      \ (\\n?(?P<extra_details>.*))?\n    $"
+    - 98
+  62: !!python/object:mt940.tags.ClosingBalance
+    re: *id001
+  62M: !!python/object:mt940.tags.IntermediateClosingBalance
+    re: *id001
+  62F: !!python/object:mt940.tags.FinalClosingBalance
+    re: *id001
+  64: !!python/object:mt940.tags.AvailableBalance
+    re: *id001
+  65: !!python/object:mt940.tags.ForwardAvailableBalance
+    re: *id001
+  86: !!python/object:mt940.tags.TransactionDetails
+    re: !!python/object/apply:re._compile
+    - "\n    (?P<transaction_details>[\\s\\S]*)\n    "
+    - 98
+  34: !!python/object:mt940.tags.FloorLimitIndicator
+    re: !!python/object/apply:re._compile
+    - "^\n    (?P<currency>[A-Z]{3})  # 3!a Currency\n    (?P<status>[DC ]?)  # 2a\
+      \ Debit/Credit Mark\n    (?P<amount>[0-9,]{0,16})  # 15d Amount (includes decimal\
+      \ sign, so 16)\n    $"
+    - 98
+  NS: !!python/object:mt940.tags.NonSwift
+    re: !!python/object/apply:re._compile
+    - "\n    (?P<non_swift>[\\s\\S]*)\n    $"
+    - 98
+  90: !!python/object:mt940.tags.SumEntries
+    re: &id002 !!python/object/apply:re._compile
+    - "^\n    (?P<number>\\d*)\n    (?P<currency>.{3})  # 3!a Currency\n    (?P<amount>[\\\
+      d,]{1,15})  # 15d Amount\n    "
+    - 98
+  90D: !!python/object:mt940.tags.SumDebitEntries
+    re: *id002
+  90C: !!python/object:mt940.tags.SumCreditEntries
+    re: *id002
+transaction_boundary: !!python/object/apply:builtins.frozenset
+- []
+transactions:
+- !!python/object:mt940.models.Transaction
+  data:
+    additional_purpose: '2017-01-01T13:12:11'
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '-6.00'
+      currency: EUR
+    applicant_bin: '12345678'
+    applicant_iban: null
+    applicant_name: null
+    bank_reference: null
+    currency: EUR
+    customer_reference: NONREF
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B+ACHQ==
+    entry_date: &id003 !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B+ADAQ==
+    extra_details: ''
+    funds_code: R
+    guessed_entry_date: *id003
+    id: N024
+    posting_text: ENTGELTABSCHLUSS
+    prima_nota: '6666'
+    purpose: Pauschalen
+    recipient_name: null
+    return_debit_notes: null
+    status: D
+    transaction_code: '805'
+    transaction_reference: STARTUMSE
+  transactions: *id004

--- a/mt940_tests/self-provided/transaction_details_wrapped.yml
+++ b/mt940_tests/self-provided/transaction_details_wrapped.yml
@@ -22,6 +22,18 @@ data:
   sequence_number: '001'
   statement_number: '00000'
   transaction_reference: STARTUMSE
+options: !!python/object/new:mt940.options.Options
+  state:
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
 tags:
   13: !!python/object:mt940.tags.DateTimeIndication
     re: !!python/object/apply:re._compile
@@ -115,7 +127,6 @@ transactions:
       - '-6.00'
       currency: EUR
     applicant_bin: '12345678'
-    applicant_iban: null
     applicant_name: null
     bank_reference: null
     currency: EUR

--- a/mt940_tests/self-provided/whitespace.all.yml
+++ b/mt940_tests/self-provided/whitespace.all.yml
@@ -1,0 +1,149 @@
+&id003 !!python/object:mt940.models.Transactions
+data:
+  account_identification: 12345678/1020304050
+  final_closing_balance: !!python/object:mt940.models.Balance
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '12345.98'
+      currency: EUR
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B+EJDg==
+    status: C
+  final_opening_balance: !!python/object:mt940.models.Balance
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '12345.12'
+      currency: EUR
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B+EJDg==
+    status: C
+  sequence_number: null
+  statement_number: '0'
+  transaction_reference: STARTUMS
+options: !!python/object/new:mt940.options.Options
+  state:
+  - true
+  - true
+  - true
+  - true
+  - true
+  - true
+  - true
+  - true
+  - true
+  - true
+tags:
+  13: !!python/object:mt940.tags.DateTimeIndication
+    re: !!python/object/apply:re._compile
+    - "^\n    (?P<year>\\d{2})\n    (?P<month>\\d{2})\n    (?P<day>\\d{2})\n    (?P<hour>\\\
+      d{2})\n    (?P<minute>\\d{2})\n    ((?P<offset_sign>[+-])(?P<offset>\\d{4}))?\n\
+      \    "
+    - 98
+  20: !!python/object:mt940.tags.TransactionReferenceNumber
+    re: !!python/object/apply:re._compile
+    - (?P<transaction_reference>.{0,16})
+    - 98
+  21: !!python/object:mt940.tags.RelatedReference
+    re: !!python/object/apply:re._compile
+    - (?P<related_reference>.{0,16})
+    - 98
+  25: !!python/object:mt940.tags.AccountIdentification
+    re: !!python/object/apply:re._compile
+    - (?P<account_identification>.{0,35})
+    - 98
+  28: !!python/object:mt940.tags.StatementNumber
+    re: !!python/object/apply:re._compile
+    - "\n    (?P<statement_number>\\d{1,5})  # 5n\n    (?:/?(?P<sequence_number>\\\
+      d{1,5}))?  # [/5n]\n    $"
+    - 98
+  60: !!python/object:mt940.tags.OpeningBalance
+    re: &id001 !!python/object/apply:re._compile
+    - "^\n    (?P<status>[DC])  # 1!a Debit/Credit\n    (?P<year>\\d{2})  # 6!n Value\
+      \ Date (YYMMDD)\n    (?P<month>\\d{2})\n    (?P<day>\\d{2})\n    (?P<currency>.{3})\
+      \  # 3!a Currency\n    (?P<amount>[0-9,]{0,16})  # 15d Amount (includes decimal\
+      \ sign, so 16)\n    "
+    - 98
+  60M: !!python/object:mt940.tags.IntermediateOpeningBalance
+    re: *id001
+  60F: !!python/object:mt940.tags.FinalOpeningBalance
+    re: *id001
+  61: !!python/object:mt940.tags.Statement
+    re: !!python/object/apply:re._compile
+    - "^\n    (?P<year>\\d{2})  # 6!n Value Date (YYMMDD)\n    (?P<month>\\d{2})\n\
+      \    (?P<day>\\d{2})\n    (?P<entry_month>\\d{2}|\\s{2})?  # [4!n] Entry Date\
+      \ (MMDD)\n    (?P<entry_day>\\d{2}|\\s{2})?\n    (?P<status>R?[DC])  # 2a Debit/Credit\
+      \ Mark\n    (?P<funds_code>[A-Z])? # [1!a] Funds Code (3rd character of the\
+      \ currency\n                            # code, if needed)\n    [\\n ]?\n  \
+      \  (?P<amount>[\\d,]{1,15})  # 15d Amount\n    (?P<id>[A-Z][A-Z0-9 ]{3})?\n\
+      \    (?P<customer_reference>((?!//)[^\\n]){0,16})\n    (//(?P<bank_reference>.{0,23}))?\n\
+      \    # Supplementary details: the SWIFT spec caps this at 34x, but some banks\n\
+      \    # (e.g. Wise, issue #117) send more, so the length limit is relaxed. This\n\
+      \    # only ever turns a previous parse error into a successful parse.\n   \
+      \ (\\n?(?P<extra_details>.*))?\n    $"
+    - 98
+  62: !!python/object:mt940.tags.ClosingBalance
+    re: *id001
+  62M: !!python/object:mt940.tags.IntermediateClosingBalance
+    re: *id001
+  62F: !!python/object:mt940.tags.FinalClosingBalance
+    re: *id001
+  64: !!python/object:mt940.tags.AvailableBalance
+    re: *id001
+  65: !!python/object:mt940.tags.ForwardAvailableBalance
+    re: *id001
+  86: !!python/object:mt940.tags.TransactionDetails
+    re: !!python/object/apply:re._compile
+    - "\n    (?P<transaction_details>[\\s\\S]*)\n    "
+    - 98
+  34: !!python/object:mt940.tags.FloorLimitIndicator
+    re: !!python/object/apply:re._compile
+    - "^\n    (?P<currency>[A-Z]{3})  # 3!a Currency\n    (?P<status>[DC ]?)  # 2a\
+      \ Debit/Credit Mark\n    (?P<amount>[0-9,]{0,16})  # 15d Amount (includes decimal\
+      \ sign, so 16)\n    $"
+    - 98
+  NS: !!python/object:mt940.tags.NonSwift
+    re: !!python/object/apply:re._compile
+    - "\n    (?P<non_swift>[\\s\\S]*)\n    $"
+    - 98
+  90: !!python/object:mt940.tags.SumEntries
+    re: &id002 !!python/object/apply:re._compile
+    - "^\n    (?P<number>\\d*)\n    (?P<currency>.{3})  # 3!a Currency\n    (?P<amount>[\\\
+      d,]{1,15})  # 15d Amount\n    "
+    - 98
+  90D: !!python/object:mt940.tags.SumDebitEntries
+    re: *id002
+  90C: !!python/object:mt940.tags.SumCreditEntries
+    re: *id002
+transaction_boundary: !!python/object/apply:builtins.frozenset
+- []
+transactions:
+- !!python/object:mt940.models.Transaction
+  data:
+    additional_purpose: null
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '-233.15'
+      currency: EUR
+    applicant_bin: '12030000'
+    applicant_iban: '9003932309'
+    applicant_name: DEUTSCHE KREDITBANK AG
+    bank_reference: null
+    currency: EUR
+    customer_reference: ''
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B+EJDg==
+    extra_details: ''
+    funds_code: null
+    id: NMSC
+    posting_text: UMBUCHUNG
+    prima_nota: '9392'
+    purpose: ERSTATTUNG AUSLANDSEINSATZENTGELT FUER VISA 4998 XXXXXXXX 1234
+    recipient_name: null
+    return_debit_notes: null
+    status: D
+    transaction_code: '820'
+    transaction_reference: STARTUMS
+  transactions: *id003

--- a/mt940_tests/self-provided/whitespace.yml
+++ b/mt940_tests/self-provided/whitespace.yml
@@ -22,6 +22,18 @@ data:
   sequence_number: null
   statement_number: '0'
   transaction_reference: STARTUMS
+options: !!python/object/new:mt940.options.Options
+  state:
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
 tags:
   13: !!python/object:mt940.tags.DateTimeIndication
     re: !!python/object/apply:re._compile
@@ -115,8 +127,7 @@ transactions:
       - '-233.15'
       currency: EUR
     applicant_bin: '12030000'
-    applicant_iban: '9003932309'
-    applicant_name: DEUTSCHE KREDITBANK AG
+    applicant_name: 9003932309DEUTSCHE KREDITBANK AG
     bank_reference: null
     currency: EUR
     customer_reference: ''

--- a/mt940_tests/self-provided/wrapped_timestamp.all.yml
+++ b/mt940_tests/self-provided/wrapped_timestamp.all.yml
@@ -1,0 +1,170 @@
+&id004 !!python/object:mt940.models.Transactions
+data:
+  account_identification: 12345678/1020304050
+  final_closing_balance: !!python/object:mt940.models.Balance
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '1194.00'
+      currency: EUR
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B+ADAQ==
+    status: C
+  final_opening_balance: !!python/object:mt940.models.Balance
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '1200.00'
+      currency: EUR
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B+ACHQ==
+    status: C
+  sequence_number: '001'
+  statement_number: '00000'
+  transaction_reference: STARTUMSE
+options: !!python/object/new:mt940.options.Options
+  state:
+  - true
+  - true
+  - true
+  - true
+  - true
+  - true
+  - true
+  - true
+  - true
+  - true
+tags:
+  13: !!python/object:mt940.tags.DateTimeIndication
+    re: !!python/object/apply:re._compile
+    - "^\n    (?P<year>\\d{2})\n    (?P<month>\\d{2})\n    (?P<day>\\d{2})\n    (?P<hour>\\\
+      d{2})\n    (?P<minute>\\d{2})\n    ((?P<offset_sign>[+-])(?P<offset>\\d{4}))?\n\
+      \    "
+    - 98
+  20: !!python/object:mt940.tags.TransactionReferenceNumber
+    re: !!python/object/apply:re._compile
+    - (?P<transaction_reference>.{0,16})
+    - 98
+  21: !!python/object:mt940.tags.RelatedReference
+    re: !!python/object/apply:re._compile
+    - (?P<related_reference>.{0,16})
+    - 98
+  25: !!python/object:mt940.tags.AccountIdentification
+    re: !!python/object/apply:re._compile
+    - (?P<account_identification>.{0,35})
+    - 98
+  28: !!python/object:mt940.tags.StatementNumber
+    re: !!python/object/apply:re._compile
+    - "\n    (?P<statement_number>\\d{1,5})  # 5n\n    (?:/?(?P<sequence_number>\\\
+      d{1,5}))?  # [/5n]\n    $"
+    - 98
+  60: !!python/object:mt940.tags.OpeningBalance
+    re: &id001 !!python/object/apply:re._compile
+    - "^\n    (?P<status>[DC])  # 1!a Debit/Credit\n    (?P<year>\\d{2})  # 6!n Value\
+      \ Date (YYMMDD)\n    (?P<month>\\d{2})\n    (?P<day>\\d{2})\n    (?P<currency>.{3})\
+      \  # 3!a Currency\n    (?P<amount>[0-9,]{0,16})  # 15d Amount (includes decimal\
+      \ sign, so 16)\n    "
+    - 98
+  60M: !!python/object:mt940.tags.IntermediateOpeningBalance
+    re: *id001
+  60F: !!python/object:mt940.tags.FinalOpeningBalance
+    re: *id001
+  61: !!python/object:mt940.tags.Statement
+    re: !!python/object/apply:re._compile
+    - "^\n    (?P<year>\\d{2})  # 6!n Value Date (YYMMDD)\n    (?P<month>\\d{2})\n\
+      \    (?P<day>\\d{2})\n    (?P<entry_month>\\d{2}|\\s{2})?  # [4!n] Entry Date\
+      \ (MMDD)\n    (?P<entry_day>\\d{2}|\\s{2})?\n    (?P<status>R?[DC])  # 2a Debit/Credit\
+      \ Mark\n    (?P<funds_code>[A-Z])? # [1!a] Funds Code (3rd character of the\
+      \ currency\n                            # code, if needed)\n    [\\n ]?\n  \
+      \  (?P<amount>[\\d,]{1,15})  # 15d Amount\n    (?P<id>[A-Z][A-Z0-9 ]{3})?\n\
+      \    (?P<customer_reference>((?!//)[^\\n]){0,16})\n    (//(?P<bank_reference>.{0,23}))?\n\
+      \    # Supplementary details: the SWIFT spec caps this at 34x, but some banks\n\
+      \    # (e.g. Wise, issue #117) send more, so the length limit is relaxed. This\n\
+      \    # only ever turns a previous parse error into a successful parse.\n   \
+      \ (\\n?(?P<extra_details>.*))?\n    $"
+    - 98
+  62: !!python/object:mt940.tags.ClosingBalance
+    re: *id001
+  62M: !!python/object:mt940.tags.IntermediateClosingBalance
+    re: *id001
+  62F: !!python/object:mt940.tags.FinalClosingBalance
+    re: *id001
+  64: !!python/object:mt940.tags.AvailableBalance
+    re: *id001
+  65: !!python/object:mt940.tags.ForwardAvailableBalance
+    re: *id001
+  86: !!python/object:mt940.tags.TransactionDetails
+    re: !!python/object/apply:re._compile
+    - "\n    (?P<transaction_details>[\\s\\S]*)\n    "
+    - 98
+  34: !!python/object:mt940.tags.FloorLimitIndicator
+    re: !!python/object/apply:re._compile
+    - "^\n    (?P<currency>[A-Z]{3})  # 3!a Currency\n    (?P<status>[DC ]?)  # 2a\
+      \ Debit/Credit Mark\n    (?P<amount>[0-9,]{0,16})  # 15d Amount (includes decimal\
+      \ sign, so 16)\n    $"
+    - 98
+  NS: !!python/object:mt940.tags.NonSwift
+    re: !!python/object/apply:re._compile
+    - "\n    (?P<non_swift>[\\s\\S]*)\n    $"
+    - 98
+  90: !!python/object:mt940.tags.SumEntries
+    re: &id002 !!python/object/apply:re._compile
+    - "^\n    (?P<number>\\d*)\n    (?P<currency>.{3})  # 3!a Currency\n    (?P<amount>[\\\
+      d,]{1,15})  # 15d Amount\n    "
+    - 98
+  90D: !!python/object:mt940.tags.SumDebitEntries
+    re: *id002
+  90C: !!python/object:mt940.tags.SumCreditEntries
+    re: *id002
+transaction_boundary: !!python/object/apply:builtins.frozenset
+- []
+transactions:
+- !!python/object:mt940.models.Transaction
+  data:
+    FRST_ONE_OFF_RECC: null
+    additional_position_date: null
+    additional_position_reference: '000000'
+    additional_purpose: null
+    amount: !!python/object:mt940.models.Amount
+      amount: !!python/object/apply:decimal.Decimal
+      - '-6.00'
+      currency: EUR
+    applicant_bin: null
+    applicant_creditor_id: XX0000000000000000ABCDEFGHIJKLMNOPQRSTUVW/PL 12-09-2014T16:26:37
+      Folgenr. 007
+    applicant_iban: null
+    applicant_name: null
+    bank_reference: null
+    compensation_amount: null
+    currency: EUR
+    customer_reference: NONREF
+    date: !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B+ACHQ==
+    debitor_identifier: null
+    deviate_applicant: null
+    deviate_recipient: null
+    end_to_end_reference: VZ0000000000000000
+    entry_date: &id003 !!python/object/apply:mt940.models.Date
+    - !!binary |
+      B+ADAQ==
+    extra_details: ''
+    funds_code: R
+    guessed_entry_date: *id003
+    gvc_applicant_bin: null
+    gvc_applicant_iban: null
+    id: N024
+    old_SEPA_CI: null
+    old_SEPA_additional_position_reference: null
+    original_amount: null
+    posting_text: 0000/661
+    prima_nota: null
+    purpose: null
+    purpose_code: null
+    recipient_name: null
+    return_debit_notes: null
+    settlement_tag: null
+    status: D
+    transaction_code: '106'
+    transaction_reference: STARTUMSE
+  transactions: *id004

--- a/mt940_tests/self-provided/wrapped_timestamp.yml
+++ b/mt940_tests/self-provided/wrapped_timestamp.yml
@@ -22,6 +22,18 @@ data:
   sequence_number: '001'
   statement_number: '00000'
   transaction_reference: STARTUMSE
+options: !!python/object/new:mt940.options.Options
+  state:
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
+  - false
 tags:
   13: !!python/object:mt940.tags.DateTimeIndication
     re: !!python/object/apply:re._compile
@@ -120,12 +132,11 @@ transactions:
     applicant_bin: null
     applicant_creditor_id: XX0000000000000000ABCDEFGHIJKLMNOPQRSTUVW/PL 12-09-2014T16:26:37
       Folgenr. 007
-    applicant_iban: null
     applicant_name: null
     bank_reference: null
     compensation_amount: null
     currency: EUR
-    customer_reference: NONREF
+    customer_reference: null
     date: !!python/object/apply:mt940.models.Date
     - !!binary |
       B+ACHQ==

--- a/mt940_tests/test_issues/test_issue130_reversal_sign.py
+++ b/mt940_tests/test_issues/test_issue130_reversal_sign.py
@@ -1,12 +1,14 @@
-"""Issue #130: the ``:61:`` reversal marks must carry the right sign.
+"""Issue #130: the ``:61:`` reversal-of-credit mark and its sign.
 
 Field 61 defines four debit/credit marks, not two: ``C``, ``D``, ``RC`` (a
 reversal of a credit) and ``RD`` (a reversal of a debit). A reversal of a
 credit takes the money back out of the account, so it belongs on the debit
 side. A reversal of a debit puts it back in.
 
-``RC`` used to come back positive, which is a silent error: nothing raised,
-nothing warned, and the figure that came out was plausible.
+Release 5.0.0 negated a plain ``D`` only, so ``RC`` came back positive, and
+that stays the default: nothing changes on upgrade. Opt in with
+``Options(reversal_sign=True)``. Lowercase marks are a separate switch,
+``Options(case_insensitive_marks=True)``.
 """
 
 import decimal
@@ -20,6 +22,8 @@ BETTERPLACE = (
     / 'betterplace'
     / 'sepa_mt9401.sta'
 )
+LEGACY = mt940.Options()
+FIXED = mt940.Options.all()
 
 
 def statement(mark: str) -> str:
@@ -32,59 +36,75 @@ def statement(mark: str) -> str:
 
 
 @pytest.mark.parametrize(
-    ('mark', 'expected'),
+    ('mark', 'legacy', 'fixed'),
     [
-        ('C', decimal.Decimal('5.00')),
-        ('D', decimal.Decimal('-5.00')),
+        ('C', '5.00', '5.00'),
+        ('D', '-5.00', '-5.00'),
         # A reversed credit is money leaving the account.
-        ('RC', decimal.Decimal('-5.00')),
+        ('RC', '5.00', '-5.00'),
         # A reversed debit is money coming back in.
-        ('RD', decimal.Decimal('5.00')),
+        ('RD', '5.00', '5.00'),
         # The tag patterns compile with re.IGNORECASE, so a lowercase mark
-        # parses and has to be signed the same way.
-        ('rc', decimal.Decimal('-5.00')),
-        ('d', decimal.Decimal('-5.00')),
+        # parses. 5.0.0 never signed it.
+        ('rc', '5.00', '-5.00'),
+        ('d', '5.00', '-5.00'),
     ],
 )
-def test_reversal_marks_get_the_sign_of_their_direction(
-    mark: str, expected: decimal.Decimal
+def test_reversal_marks_default_and_opt_in(
+    mark: str, legacy: str, fixed: str
 ) -> None:
-    transactions = mt940.parse(statement(mark))
-    assert len(transactions) == 1
-    transaction = transactions[0]
-    assert transaction.data['status'] == mark
-    assert transaction.data['amount'].amount == expected
+    for options, expected in ((LEGACY, legacy), (FIXED, fixed)):
+        transactions = mt940.parse(statement(mark), options=options)
+        assert len(transactions) == 1
+        transaction = transactions[0]
+        assert transaction.data['status'] == mark
+        assert transaction.data['amount'].amount == decimal.Decimal(expected)
 
 
-def test_reversed_credits_in_the_betterplace_statement_are_negative() -> None:
+@pytest.mark.parametrize(
+    ('options', 'expected'),
+    [(LEGACY, '204.88'), (FIXED, '-204.88')],
+)
+def test_reversed_credits_in_the_betterplace_statement(
+    options: mt940.Options, expected: str
+) -> None:
     # This file ships with the library and carries two RC entries of 204,88.
     reversals = [
         transaction
-        for transaction in mt940.parse(BETTERPLACE)
+        for transaction in mt940.parse(BETTERPLACE, options=options)
         if transaction.data['status'] == 'RC'
     ]
     assert len(reversals) == 2
     for transaction in reversals:
-        assert transaction.data['amount'].amount == decimal.Decimal('-204.88')
+        assert transaction.data['amount'].amount == decimal.Decimal(expected)
 
 
-def test_every_betterplace_statement_matches_its_own_closing_balance() -> None:
+@pytest.mark.parametrize(
+    ('options', 'expected_mismatches'),
+    [(LEGACY, 2), (FIXED, 0)],
+)
+def test_betterplace_statements_against_their_own_closing_balance(
+    options: mt940.Options, expected_mismatches: int
+) -> None:
     # The bank states its own opening and closing balance in :60F: and :62F:,
     # so the entries in between have to add up to the difference. This is the
-    # arithmetic that the RC sign used to break: the two statements holding a
-    # reversal each computed a closing balance 409,76 HIGHER than the one the
-    # bank states, which is twice the 204,88 that was counted as arriving
+    # arithmetic that the 5.0.0 sign breaks: the two statements holding a
+    # reversal each compute a closing balance 409,76 HIGHER than the one the
+    # bank states, which is twice the 204,88 that is counted as arriving
     # instead of leaving.
     #
     # parse_statements rather than parse, because parse merges every block of
     # the file into one Transactions and keeps only the last pair of balances.
     checked = 0
+    mismatches = 0
 
-    for transactions in mt940.parse_statements(BETTERPLACE):
+    for transactions in mt940.parse_statements(BETTERPLACE, options=options):
         opening = transactions.data.get('final_opening_balance')
         closing = transactions.data.get('final_closing_balance')
         if opening is None or closing is None:
             continue
+        assert isinstance(opening.amount, mt940.models.Amount)
+        assert isinstance(closing.amount, mt940.models.Amount)
 
         total = sum(
             (
@@ -93,9 +113,11 @@ def test_every_betterplace_statement_matches_its_own_closing_balance() -> None:
             ),
             decimal.Decimal(0),
         )
-        assert opening.amount.amount + total == closing.amount.amount
+        if opening.amount.amount + total != closing.amount.amount:
+            mismatches += 1
         checked += 1
 
     # Pinned so the test cannot quietly become vacuous if the file or the
     # splitting changes.
     assert checked == 15
+    assert mismatches == expected_mismatches

--- a/mt940_tests/test_issues/test_issue132_applicant_iban.py
+++ b/mt940_tests/test_issues/test_issue132_applicant_iban.py
@@ -1,8 +1,9 @@
 """Issue #132: ``?31`` is the counterparty account, not part of the name.
 
 5.0.0 mapped ``?31`` onto ``applicant_name``, so the account number was
-welded to the front of the name and ``applicant_iban`` disappeared. The
-mapping from 4.30.0 is restored.
+welded to the front of the name and ``applicant_iban`` disappeared. That
+stays the default. ``Options(applicant_iban=True)`` restores the 4.30.0
+mapping.
 """
 
 import pathlib
@@ -11,12 +12,20 @@ import mt940
 
 FIXTURES = pathlib.Path(__file__).resolve().parent.parent
 SEPA_SNIPPET = FIXTURES / 'betterplace' / 'sepa_snippet.sta'
+FIXED = mt940.Options(applicant_iban=True)
 
 
-def test_applicant_iban_has_its_own_field() -> None:
-    transaction = mt940.parse(SEPA_SNIPPET)[0].data
-    assert transaction['applicant_iban'] == 'DE14508800500194785000'
-    assert transaction['applicant_name'] == 'KARL        KAUFMANN'
+def test_applicant_iban_is_opt_in() -> None:
+    legacy = mt940.parse(SEPA_SNIPPET)[0].data
+    assert 'applicant_iban' not in legacy
+    assert (
+        legacy['applicant_name']
+        == 'DE14508800500194785000KARL        KAUFMANN'
+    )
+
+    fixed = mt940.parse(SEPA_SNIPPET, options=FIXED)[0].data
+    assert fixed['applicant_iban'] == 'DE14508800500194785000'
+    assert fixed['applicant_name'] == 'KARL        KAUFMANN'
 
 
 def test_plain_account_numbers_land_in_the_same_field() -> None:
@@ -30,7 +39,12 @@ def test_plain_account_numbers_land_in_the_same_field() -> None:
 :86:051?00UEBERWEISUNG?20PURPOSE?30BANK?31234567?32SOME?33 NAME
 :62F:C200101EUR110,00
 """
-    transaction = mt940.parse(data)[0].data
-    assert transaction['applicant_bin'] == 'BANK'
-    assert transaction['applicant_iban'] == '234567'
-    assert transaction['applicant_name'] == 'SOME NAME'
+    legacy = mt940.parse(data)[0].data
+    assert legacy['applicant_bin'] == 'BANK'
+    assert 'applicant_iban' not in legacy
+    assert legacy['applicant_name'] == '234567SOME NAME'
+
+    fixed = mt940.parse(data, options=FIXED)[0].data
+    assert fixed['applicant_bin'] == 'BANK'
+    assert fixed['applicant_iban'] == '234567'
+    assert fixed['applicant_name'] == 'SOME NAME'

--- a/mt940_tests/test_models.py
+++ b/mt940_tests/test_models.py
@@ -1,3 +1,9 @@
+import datetime
+import decimal
+import typing
+
+import mt940
+import mt940._types
 import pytest
 from mt940 import models
 
@@ -6,12 +12,20 @@ def test_model_repr_uses_the_class_name() -> None:
     assert repr(models.Model()) == '<Model>'
 
 
-def test_balance_empty_amount_string_is_none() -> None:
-    # A malformed :60F: may carry no amount at all. That is a missing value,
-    # not an empty string and not an error.
+def test_balance_empty_amount_string_is_stored_as_is() -> None:
+    # 5.0.0 stored an empty amount string unchanged, so that stays: it is
+    # neither coerced to an Amount nor turned into None.
     balance = models.Balance(amount='', status='C', currency='EUR')
-    assert balance.amount is None
+    assert balance.amount == ''  # noqa: PLC1901 (the exact value matters)
     assert balance.status == 'C'
+    assert str(balance) == ' @ None'
+
+
+def test_amount_without_a_status_is_positive() -> None:
+    # 5.0.0 compared the mark to 'D' and None simply did not match.
+    amount = models.Amount('1.00', None, 'EUR')
+    assert amount.amount == decimal.Decimal('1.00')
+    assert amount.currency == 'EUR'
 
 
 def test_balance_amount_string_needs_a_status() -> None:
@@ -49,8 +63,11 @@ def test_currency_is_none_without_a_signed_amount() -> None:
     transactions = models.Transactions()
     assert transactions.currency is None
 
-    # A balance that parsed without an amount carries no currency either.
+    # A balance that parsed without an amount carries no currency either,
+    # and neither does one holding the empty amount string.
     transactions.data['final_opening_balance'] = models.Balance(status='C')
+    assert transactions.currency is None
+    transactions.data['final_opening_balance'] = models.Balance('C', '')
     assert transactions.currency is None
 
     transactions.data['final_opening_balance'] = models.Balance(
@@ -59,31 +76,139 @@ def test_currency_is_none_without_a_signed_amount() -> None:
     assert transactions.currency == 'USD'
 
 
+class _Duck:
+    """Something that is not a Balance but carries a currency."""
+
+    currency: str = 'GBP'
+
+
+class _DuckWithAmount:
+    """Something that is not a Balance but wraps an object with a currency."""
+
+    def __init__(self) -> None:
+        self.amount: models.Amount = models.Amount('1,00', 'C', 'JPY')
+
+
+class _DuckWithoutCurrency:
+    """Something whose currency attribute is present but not a string."""
+
+    currency: None = None
+    amount: models.Amount = models.Amount('1,00', 'C', 'JPY')
+
+
+def _currency_with(balance: object) -> str | None:
+    transactions = models.Transactions()
+    transactions.data['opening_balance'] = balance
+    return transactions.currency
+
+
+@pytest.mark.parametrize(
+    ('balance', 'expected'),
+    [
+        (_Duck(), 'GBP'),
+        (_DuckWithAmount(), 'JPY'),
+        (_DuckWithoutCurrency(), None),
+        (object(), None),
+    ],
+    ids=['currency', 'amount.currency', 'non-string currency', 'nothing'],
+)
+def test_currency_duck_types_like_5_0_0(
+    balance: object, expected: str | None
+) -> None:
+    # 5.0.0 accepted any object with a currency, or with an amount that has
+    # one, in the balance slots. Nothing usable gives None instead of an
+    # AttributeError.
+    assert _currency_with(balance) == expected
+
+
 def test_currency_from_a_bare_floor_limit() -> None:
     transactions = models.Transactions()
     transactions.data['c_floor_limit'] = models.Amount('1,00', 'C', 'CHF')
     assert transactions.currency == 'CHF'
 
 
-def test_scope_marker_cannot_be_instantiated() -> None:
-    # TransactionsAndTransaction only exists for issubclass checks on
-    # Tag.scope, so building one is a programming error.
-    with pytest.raises(TypeError, match='scope marker'):
-        _ = models.TransactionsAndTransaction()
+def test_scope_marker_is_a_subclass_of_both_and_instantiable() -> None:
+    # TransactionsAndTransaction exists for issubclass checks on Tag.scope.
+    # Building one worked in 5.0.0 (it runs Transactions.__init__), so it
+    # still does.
     assert issubclass(models.TransactionsAndTransaction, models.Transactions)
     assert issubclass(models.TransactionsAndTransaction, models.Transaction)
+    marker = models.TransactionsAndTransaction()
+    assert isinstance(marker, models.Transactions)
+    assert isinstance(marker, models.Transaction)
+    assert len(marker) == 0
 
 
-def test_sum_amount_equality_includes_the_entry_count() -> None:
-    # CodeQL py/missing-equals: SumAmount adds `number`, so two totals over
-    # a different number of entries must not compare equal.
+def test_sum_amount_equality_ignores_the_entry_count() -> None:
+    # 5.0.0 semantics: SumAmount compares like the Amount it is, so a plain
+    # Amount of the same value is equal and so are two totals over a
+    # different number of entries. The explicit __eq__ keeps CodeQL's
+    # py/missing-equals satisfied without changing that.
     two = models.SumAmount('10,00', 'C', 'EUR', number=2)
     also_two = models.SumAmount('10,00', 'C', 'EUR', number=2)
     three = models.SumAmount('10,00', 'C', 'EUR', number=3)
     plain = models.Amount('10,00', 'C', 'EUR')
+    other = models.SumAmount('11,00', 'C', 'EUR', number=2)
 
     assert two == also_two
-    assert hash(two) == hash(also_two)
-    assert two != three
-    assert two != plain
-    assert len({two, also_two, three}) == 2
+    assert two == three
+    assert two == plain
+    assert plain == two
+    assert two != other
+    assert hash(two) == hash(three) == hash(plain)
+    assert len({two, also_two, three, plain}) == 1
+
+
+def test_fixed_offset_methods_accept_the_dt_keyword() -> None:
+    # The tzinfo methods took `dt` as a keyword in 5.0.0.
+    offset = models.FixedOffset(60, 'CET')
+    assert offset.utcoffset(dt=None) == datetime.timedelta(minutes=60)
+    assert offset.dst(dt=None) == datetime.timedelta(0)
+    assert offset.tzname(dt=None) == 'CET'
+
+
+def test_processors_alias_is_exported_at_runtime() -> None:
+    # 5.0.0 exposed the Processors alias on mt940.models.
+    assert models.Processors is mt940._types.Processors
+
+
+def test_processor_protocol_hints_resolve_at_runtime() -> None:
+    # The protocol signatures name no package class, so get_type_hints
+    # works without importing anything, as in 5.0.0.
+    hints = typing.get_type_hints(mt940._types.PreProcessor.__call__)
+    assert hints['transactions'] is typing.Any
+    hints = typing.get_type_hints(mt940._types.PostProcessor.__call__)
+    assert hints['tag'] is typing.Any
+
+
+def test_unpickling_state_without_options_gets_the_defaults() -> None:
+    # Pickles written by 5.0.0 carry no options attribute.
+    state = models.Transactions().__getstate__()
+    del state['options']
+    restored = models.Transactions.__new__(models.Transactions)
+    restored.__setstate__(state)
+    assert restored.options == mt940.Options()
+
+
+@pytest.mark.parametrize(
+    ('status', 'options', 'sign'),
+    [
+        ('D', mt940.Options(), -1),
+        ('RC', mt940.Options(), 1),
+        ('d', mt940.Options(), 1),
+        ('rc', mt940.Options(), 1),
+        ('RC', mt940.Options(reversal_sign=True), -1),
+        ('d', mt940.Options(case_insensitive_marks=True), -1),
+        ('rc', mt940.Options(reversal_sign=True), 1),
+        ('rc', mt940.Options.all(), -1),
+        ('RD', mt940.Options.all(), 1),
+    ],
+)
+def test_amount_signing_follows_the_options(
+    status: str, options: mt940.Options, sign: int
+) -> None:
+    # 5.0.0 negated a plain D only. Reversals and lowercase marks are signed
+    # on request, and a reversed debit stays positive whatever is switched
+    # on.
+    amount = models.Amount('1.00', status, 'EUR', options=options)
+    assert amount.amount == sign * decimal.Decimal('1.00')

--- a/mt940_tests/test_parse.py
+++ b/mt940_tests/test_parse.py
@@ -1,8 +1,10 @@
 import os
 import pathlib
 import pickle
+import typing
 
 import mt940
+import mt940._types
 import pytest
 
 _tests_path = pathlib.Path(__file__).parent
@@ -42,20 +44,34 @@ _ACCENTED_STATEMENT = _BOM_STATEMENT.replace(
 )
 
 
-def test_utf8_bom_bytes_does_not_drop_first_tag() -> None:
-    # A UTF-8 BOM (emitted by many Windows tools/banks) must not push the
-    # leading :20: past the start-of-line tag anchor and drop its data.
-    data = b'\xef\xbb\xbf' + _BOM_STATEMENT.encode('utf-8')
+_BOM_BYTES = b'\xef\xbb\xbf' + _BOM_STATEMENT.encode('utf-8')
+
+
+@pytest.mark.parametrize(
+    'data', [_BOM_BYTES, '﻿' + _BOM_STATEMENT], ids=['bytes', 'str']
+)
+def test_bom_drops_the_first_tag_by_default(data: bytes | str) -> None:
+    # 5.0.0 kept a leading BOM. It is not whitespace, so it pushes the
+    # leading :20: past the start-of-line tag anchor and that tag's data is
+    # lost, and parse_statements finds no statement at all.
     transactions = mt940.parse(data)
-    assert transactions.data.get('transaction_reference') == 'REF'
+    assert 'transaction_reference' not in transactions.data
     assert len(transactions) == 1
+    assert mt940.parse_statements(data) == []
 
 
-def test_utf8_bom_str_does_not_drop_first_tag() -> None:
-    # Same file already decoded to str with a stray BOM character.
-    transactions = mt940.parse('﻿' + _BOM_STATEMENT)
+@pytest.mark.parametrize(
+    'data', [_BOM_BYTES, '﻿' + _BOM_STATEMENT], ids=['bytes', 'str']
+)
+def test_strip_bom_option_keeps_the_first_tag(data: bytes | str) -> None:
+    # A UTF-8 BOM (emitted by many Windows tools/banks) is dropped on
+    # request, and the :20: parses.
+    options = mt940.Options(strip_bom=True)
+    transactions = mt940.parse(data, options=options)
     assert transactions.data.get('transaction_reference') == 'REF'
     assert len(transactions) == 1
+    statements = mt940.parse_statements(data, options=options)
+    assert [s.data['transaction_reference'] for s in statements] == ['REF']
 
 
 def test_string_that_is_not_a_path_is_parsed_as_data() -> None:
@@ -74,9 +90,48 @@ def test_bytes_path_parses_like_a_str_path() -> None:
 
 def test_missing_path_like_source_raises() -> None:
     # A str that is not a file is statement data. A path-like object cannot
-    # be, so a missing one is an error rather than an empty parse.
+    # be, so a missing one is an error rather than an empty parse. 5.0.0
+    # raised a bare AssertionError here, this is the one deliberate change
+    # of exception type.
     with pytest.raises(FileNotFoundError, match=r'statement\.sta'):
         _ = mt940.parse(pathlib.Path('/nonexistent/statement.sta'))
+
+
+class _StatementWithRead(str):  # noqa: FURB189 (a str subclass is the point)
+    """A str that also has a read() method, which 5.0.0 read through."""
+
+    __slots__: typing.ClassVar[tuple[str, ...]] = ()
+
+    def read(self) -> str:
+        return self.replace('REF', 'FROM-READ')
+
+
+def test_anything_with_a_read_method_is_read_first() -> None:
+    # 5.0.0 checked for read() before anything else, so even a str
+    # subclass is treated as a handle.
+    transactions = mt940.parse(_StatementWithRead(_BOM_STATEMENT))
+    assert transactions.data['transaction_reference'] == 'FROM-READ'
+
+
+def test_file_descriptor_is_read_and_closed() -> None:
+    # 5.0.0 accepted an int through os.path.isfile and open(), which closes
+    # the descriptor on the way out.
+    fd = os.open(_ING, os.O_RDONLY)
+    transactions = mt940.parse(fd)
+    assert len(transactions) == len(mt940.parse(_ING))
+    with pytest.raises(OSError, match='Bad file descriptor'):
+        _ = os.fstat(fd)
+
+
+@pytest.mark.parametrize(
+    'source',
+    [None, [':20:REF'], bytearray(b':20:REF'), memoryview(b':20:REF')],
+    ids=['none', 'list', 'bytearray', 'memoryview'],
+)
+def test_unsupported_sources_raise_type_error(source: object) -> None:
+    # 5.0.0 raised TypeError out of os.stat for these.
+    with pytest.raises(TypeError, match='unsupported source type'):
+        _ = mt940.parse(typing.cast('mt940._types.Source', source))
 
 
 def test_explicit_encoding_is_tried_first() -> None:
@@ -196,3 +251,43 @@ def test_pickle_roundtrip_preserves_transaction_boundary() -> None:
     assert restored.transaction_boundary == frozenset({
         'transaction_reference_number'
     })
+
+
+_TWO_86_STATEMENT = """:20:REF
+:25:NL
+:28C:1/1
+:60F:C091019EUR1000,00
+:61:0910201020C500,00NTRFCUSTREF//BANKREF
+:86:166?00SEPA?20SVWZ+one
+:86:166?00SEPA?20KREF+K2?21SVWZ+two
+:62F:C091020EUR1500,00
+"""
+
+
+def test_structured_86_none_overwrites_by_default() -> None:
+    # 5.0.0 semantics: the first structured :86: carries no KREF, so its
+    # customer_reference of None replaces the one from :61:. The second
+    # :86: then replaces that None with its KREF. (5.0.0 itself crashed on
+    # the second tag with None += str, that part is a plain fix.)
+    transaction = mt940.parse(_TWO_86_STATEMENT)[0].data
+    assert transaction['customer_reference'] == 'K2'
+    assert transaction['purpose'] == 'one\ntwo'
+
+
+def test_merge_keeps_values_option_preserves_existing_values() -> None:
+    # With the option a None never replaces a value another tag provided,
+    # so the :61: reference survives and the KREF is appended to it.
+    options = mt940.Options(merge_keeps_values=True)
+    transaction = mt940.parse(_TWO_86_STATEMENT, options=options)[0].data
+    assert transaction['customer_reference'] == 'CUSTREF\nK2'
+    assert transaction['purpose'] == 'one\ntwo'
+
+
+def test_merge_keeps_values_option_still_fills_missing_keys() -> None:
+    # A key that no earlier tag provided is set even when its value is
+    # None, in both modes.
+    statement = _TWO_86_STATEMENT.replace('KREF+K2?21', '')
+    for options in (mt940.Options(), mt940.Options(merge_keeps_values=True)):
+        transaction = mt940.parse(statement, options=options)[0].data
+        assert 'applicant_creditor_id' in transaction
+        assert transaction['applicant_creditor_id'] is None

--- a/mt940_tests/test_processors.py
+++ b/mt940_tests/test_processors.py
@@ -215,8 +215,17 @@ def test_json_round_trip_sum_amount_and_datetime() -> None:
         'currency': 'PLN',
         'number': '3',
     }
-    # The :13D: DateTime (with a +0100 FixedOffset) renders as an ISO string,
-    # carrying the timezone offset, not a mapping.
+    # The :13D: DateTime renders as an ISO string carrying the timezone
+    # offset, not a mapping. 5.0.0 read the +0100 subfield as 100 minutes.
+    assert decoded['date'] == '2017-01-19 18:15:00+01:40'
+
+
+def test_json_round_trip_datetime_with_timezone_offset_option() -> None:
+    transactions = mt940.parse(
+        str(_tests_path / 'mBank' / 'mt942.sta'),
+        options=mt940.Options(timezone_offset=True),
+    )
+    decoded = json.loads(json.dumps(transactions, cls=mt940.JSONEncoder))
     assert decoded['date'] == '2017-01-19 18:15:00+01:00'
 
 
@@ -260,25 +269,26 @@ def test_date_fixup_non_leap_february_clamped() -> None:
 
 
 @pytest.mark.parametrize(
-    ('detail', 'expected_purpose'),
+    ('detail', 'legacy_purpose', 'fixed_purpose'),
     [
         # A literal '+' inside the first characters of free text (e.g. a
-        # company name like "AB+...") must not be treated as a GVC KEYWORD+
-        # separator: EREF is a real GVC key later in the text, so gvcodes runs.
-        ('020?20AB+EREF', 'AB+EREF'),
-        # 'A+B' at the very start must survive. SVWZ triggers gvcodes parsing.
-        ('020?20A+B SVWZ TEXT', 'A+B SVWZ TEXT'),
+        # company name like "AB+...") is not a GVC KEYWORD+ separator: EREF
+        # is a real GVC key later in the text, so gvcodes runs.
+        ('020?20AB+EREF', 'EREF', 'AB+EREF'),
+        # 'A+B' at the very start. SVWZ triggers gvcodes parsing.
+        ('020?20A+B SVWZ TEXT', 'B SVWZ TEXT', 'A+B SVWZ TEXT'),
     ],
 )
-def test_gvcode_leading_plus_in_free_text_kept_in_purpose(
-    detail: str, expected_purpose: str
+def test_gvcode_leading_plus_in_free_text(
+    detail: str, legacy_purpose: str, fixed_purpose: str
 ) -> None:
     """A '+' earlier than position 4 cannot terminate a GVC keyword.
 
-    GVC keywords are 3-4 chars followed by '+'. ``_parse_mt940_gvcodes`` sliced
+    GVC keywords are four characters followed by '+'. 5.0.0 sliced
     ``purpose[index - 4:index]`` without a lower bound, so a '+' at index < 4
-    produced a wrapped/empty slice matching the empty-string GVC key and
-    truncated the purpose (dropping the leading free text before the '+').
+    produced a wrapped, empty slice matching the empty-string GVC key and
+    dropped the free text in front of the '+'. That stays the default,
+    ``Options(gvc_leading_text=True)`` keeps the text.
     """
     data = (
         ':20:REF\n'
@@ -289,8 +299,9 @@ def test_gvcode_leading_plus_in_free_text_kept_in_purpose(
         f':86:{detail}\n'
         ':62F:C200101EUR110,00\n'
     )
-    transaction = mt940.parse(data)[0].data
-    assert transaction['purpose'] == expected_purpose
+    assert mt940.parse(data)[0].data['purpose'] == legacy_purpose
+    fixed = mt940.parse(data, options=mt940.Options(gvc_leading_text=True))
+    assert fixed[0].data['purpose'] == fixed_purpose
 
 
 def _two_structured_86_data(first_detail: str, second_detail: str) -> str:
@@ -307,39 +318,67 @@ def _two_structured_86_data(first_detail: str, second_detail: str) -> str:
 
 
 @pytest.mark.parametrize(
-    ('first_detail', 'second_detail'),
+    ('first_detail', 'second_detail', 'legacy_purpose', 'legacy_posting'),
     [
-        ('020?20REALPURPOSE', '020?00POSTINGTEXT'),
-        ('020?00POSTINGTEXT', '020?20REALPURPOSE'),
+        ('020?20REALPURPOSE', '020?00POSTINGTEXT', None, 'POSTINGTEXT'),
+        ('020?00POSTINGTEXT', '020?20REALPURPOSE', 'REALPURPOSE', None),
     ],
 )
-def test_repeated_structured_86_keeps_real_values_in_either_order(
-    first_detail: str, second_detail: str
+def test_repeated_structured_86_merge(
+    first_detail: str,
+    second_detail: str,
+    legacy_purpose: str | None,
+    legacy_posting: str | None,
 ) -> None:
-    """Two structured ``:86:`` tags on one ``:61:`` merge without loss.
+    """Two structured ``:86:`` tags on one ``:61:`` merge without a crash.
 
     A structured ``:86:`` emits every ``DETAIL_KEYS`` value, ``None`` for the
-    sub-fields it does not carry. A second one used to hit ``None += str`` in
-    ``_update_transaction`` and abort the parse, and once that was fixed its
-    ``None`` values still overwrote the first tag's real values. A ``None``
-    never replaces an existing value now, so both tags' values survive.
+    sub-fields it does not carry. 5.0.0 hit ``None += str`` in one order and
+    aborted the parse, which stays fixed, and in the other order let the
+    later ``None`` overwrite the earlier real value, which stays the default.
+    With ``Options(merge_keeps_values=True)`` a ``None`` never replaces an
+    existing value, so both tags' values survive in either order.
     """
-    transaction = mt940.parse(
-        _two_structured_86_data(first_detail, second_detail)
-    )[0].data
-    assert transaction['purpose'] == 'REALPURPOSE'
-    assert transaction['posting_text'] == 'POSTINGTEXT'
+    data = _two_structured_86_data(first_detail, second_detail)
+    legacy = mt940.parse(data)[0].data
+    assert legacy['purpose'] == legacy_purpose
+    assert legacy['posting_text'] == legacy_posting
+
+    kept = mt940.parse(data, options=mt940.Options(merge_keeps_values=True))
+    assert kept[0].data['purpose'] == 'REALPURPOSE'
+    assert kept[0].data['posting_text'] == 'POSTINGTEXT'
 
 
-def test_structured_86_without_kref_keeps_the_61_customer_reference() -> None:
+def test_structured_86_without_kref_and_the_61_customer_reference() -> None:
     # The :61: carries the customer reference. A structured :86: without a
-    # KREF emits customer_reference=None, which used to null the real value
-    # in nine fixtures from four banks.
+    # KREF emits customer_reference=None, which nulls the real value in nine
+    # fixtures from four banks under the 5.0.0 rule.
     data = _two_structured_86_data('020?20PURPOSE', '020?00TEXT').replace(
         'NTRFNONREF', 'NTRFTFNR 40001'
     )
-    transaction = mt940.parse(data)[0].data
-    assert transaction['customer_reference'] == 'TFNR 40001'
+    assert mt940.parse(data)[0].data['customer_reference'] is None
+    kept = mt940.parse(data, options=mt940.Options(merge_keeps_values=True))
+    assert kept[0].data['customer_reference'] == 'TFNR 40001'
+
+
+def test_detail_key_mappings() -> None:
+    # DETAIL_KEYS is the 5.0.0 mapping, the ?31 variant is a separate
+    # constant with the same keys in the same order.
+    assert mt940.processors.DETAIL_KEYS['31'] == 'applicant_name'
+    assert (
+        mt940.processors.DETAIL_KEYS_APPLICANT_IBAN['31'] == 'applicant_iban'
+    )
+    assert list(mt940.processors.DETAIL_KEYS_APPLICANT_IBAN) == list(
+        mt940.processors.DETAIL_KEYS
+    )
+
+
+def test_processor_protocols_are_importable_from_processors() -> None:
+    # 5.0.0 exposed the protocols here, typed user code imports them here.
+    for name in ('PreProcessor', 'PostProcessor'):
+        protocol = getattr(mt940.processors, name)
+        assert protocol.__module__ == 'mt940._types'
+        assert protocol.__name__ == name
 
 
 def test_add_currency_pre_processor_can_keep_an_existing_currency() -> None:

--- a/mt940_tests/test_sta_parsing.py
+++ b/mt940_tests/test_sta_parsing.py
@@ -41,30 +41,61 @@ def get_sta_files() -> list[str]:
     return sorted(str(path) for path in base_path.rglob('*.sta'))
 
 
-def _golden_path(sta_file: str) -> pathlib.Path:
-    return pathlib.Path(sta_file).with_suffix('.yml')
+#: Every fixture is parsed once per mode. The default mode pins the 5.0.0
+#: output, the ``all`` mode pins the output with every opt-in fix enabled.
+MODES: dict[str, mt940.Options] = {
+    'default': mt940.Options(),
+    'all': mt940.Options.all(),
+}
 
 
-def get_yaml_data(sta_file: str) -> object:
-    with _golden_path(sta_file).open(encoding='utf-8') as fh:
+def _golden_path(sta_file: str, mode: str = 'default') -> pathlib.Path:
+    # ``x.yml`` for the default mode, ``x.<mode>.yml`` for the others.
+    suffix = '.yml' if mode == 'default' else f'.{mode}.yml'
+    return pathlib.Path(sta_file).with_suffix(suffix)
+
+
+def get_yaml_data(sta_file: str, mode: str = 'default') -> object:
+    path = _golden_path(sta_file, mode)
+    if not path.exists():
+        # The fixes leave this fixture unchanged, the default golden applies.
+        path = _golden_path(sta_file)
+    with path.open(encoding='utf-8') as fh:
         # The goldens carry the !!python tags written by write_yaml_data, so
         # only the full Loader can read them back.
         data: object = yaml.load(fh, Loader=yaml.Loader)  # noqa: S506
     return data
 
 
-def write_yaml_data(sta_file: str, data: object) -> None:
-    _ = _golden_path(sta_file).write_text(
+def write_yaml_data(
+    sta_file: str, data: object, mode: str = 'default'
+) -> None:
+    _ = _golden_path(sta_file, mode).write_text(
         yaml.dump(data, Dumper=yaml.Dumper), encoding='utf-8'
     )
 
 
+def _as_json(transactions: mt940.models.Transactions) -> str:
+    return json.dumps(transactions, cls=mt940.JSONEncoder, sort_keys=True)
+
+
 def maybe_write_golden(
-    sta_file: str, transactions: mt940.models.Transactions
+    sta_file: str,
+    transactions: mt940.models.Transactions,
+    mode: str = 'default',
 ) -> None:
-    # Development only: regenerate the golden next to the fixture.
-    if os.environ.get('WRITE_YAML_FILES'):
-        write_yaml_data(sta_file, transactions)
+    # Development only: regenerate the golden next to the fixture. A non
+    # default mode only gets its own golden when its output differs from the
+    # default one, so the fixture tree shows exactly which files the fixes
+    # change.
+    if not os.environ.get('WRITE_YAML_FILES'):
+        return
+    if mode != 'default' and _as_json(transactions) == _as_json(
+        mt940.parse(sta_file)
+    ):
+        _golden_path(sta_file, mode).unlink(missing_ok=True)
+        return
+    write_yaml_data(sta_file, transactions, mode)
 
 
 def _path(keys: list[str]) -> str:
@@ -294,11 +325,37 @@ def test_maybe_write_golden_honours_the_environment(
     assert _golden_path(sta_file).exists()
 
 
+def test_maybe_write_golden_keeps_a_mode_only_when_it_differs(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # A lowercase debit mark only changes the output with the fixes on.
+    sta_file = str(tmp_path / 'statement.sta')
+    _ = pathlib.Path(sta_file).write_text(
+        _STATEMENT.replace('C10,00', 'd10,00'), encoding='utf-8'
+    )
+    monkeypatch.setenv('WRITE_YAML_FILES', '1')
+
+    maybe_write_golden(sta_file, mt940.parse(sta_file), 'default')
+    maybe_write_golden(sta_file, mt940.parse(sta_file), 'all')
+    assert not _golden_path(sta_file, 'all').exists()
+    compare(get_yaml_data(sta_file, 'all'), mt940.parse(sta_file))
+
+    fixed = mt940.parse(sta_file, options=MODES['all'])
+    maybe_write_golden(sta_file, fixed, 'all')
+    assert _golden_path(sta_file, 'all').exists()
+    compare(get_yaml_data(sta_file, 'all'), fixed)
+
+    # Back to identical output: the stale mode golden is removed again.
+    maybe_write_golden(sta_file, mt940.parse(sta_file), 'all')
+    assert not _golden_path(sta_file, 'all').exists()
+
+
+@pytest.mark.parametrize('mode', sorted(MODES))
 @pytest.mark.parametrize('sta_file', get_sta_files())
-def test_parse(sta_file: str) -> None:
-    transactions = mt940.parse(sta_file)
-    maybe_write_golden(sta_file, transactions)
-    expected = get_yaml_data(sta_file)
+def test_parse(sta_file: str, mode: str) -> None:
+    transactions = mt940.parse(sta_file, options=MODES[mode])
+    maybe_write_golden(sta_file, transactions, mode)
+    expected = get_yaml_data(sta_file, mode)
     assert isinstance(expected, mt940.models.Transactions)
 
     # Every model has to render without raising.
@@ -319,9 +376,10 @@ def test_parse(sta_file: str) -> None:
     compare(expected[:], transactions[:])
 
 
+@pytest.mark.parametrize('mode', sorted(MODES))
 @pytest.mark.parametrize('sta_file', get_sta_files())
-def test_json_dump(sta_file: str) -> None:
-    transactions = mt940.parse(sta_file)
+def test_json_dump(sta_file: str, mode: str) -> None:
+    transactions = mt940.parse(sta_file, options=MODES[mode])
     decoded: object = json.loads(
         json.dumps(transactions, cls=mt940.JSONEncoder)
     )

--- a/mt940_tests/test_tags.py
+++ b/mt940_tests/test_tags.py
@@ -14,85 +14,242 @@ _HEADER = _PREAMBLE + _OPENING
 _FOOTER = ':62F:C231229EUR10,00\n'
 
 
-def test_date_time_indication_positive_offset_is_hhmm() -> None:
-    # The :13(D): offset subfield is HHMM (like ISO 8601 +0130), not a
-    # number of minutes: +0130 means 1 hour 30 minutes.
-    transactions = mt940.parse(':13D:1701191815+0130\n' + _HEADER + _FOOTER)
+_ALL = mt940.Options.all()
+
+
+@pytest.mark.parametrize(
+    ('options', 'expected_offset', 'expected_name'),
+    [
+        # 5.0.0 handed the HHMM digits to FixedOffset as a minute count.
+        (mt940.Options(), datetime.timedelta(minutes=130), '0130'),
+        # The subfield is HHMM (like ISO 8601 +0130): one hour and thirty
+        # minutes east of UTC.
+        (
+            mt940.Options(timezone_offset=True),
+            datetime.timedelta(hours=1, minutes=30),
+            '90',
+        ),
+    ],
+)
+def test_date_time_indication_positive_offset(
+    options: mt940.Options,
+    expected_offset: datetime.timedelta,
+    expected_name: str,
+) -> None:
+    transactions = mt940.parse(
+        ':13D:1701191815+0130\n' + _HEADER + _FOOTER, options=options
+    )
     date = transactions.data['date']
-    assert date.utcoffset() == datetime.timedelta(hours=1, minutes=30)
+    assert date.utcoffset() == expected_offset
+    assert date.tzname() == expected_name
 
 
-def test_date_time_indication_negative_offset() -> None:
-    # 1!x sign can be '-' as well (e.g. US banks): -0500 is UTC-5.
-    transactions = mt940.parse(':13D:1701191815-0500\n' + _HEADER + _FOOTER)
+@pytest.mark.parametrize(
+    ('options', 'expected_offset', 'expected_name'),
+    [
+        # 5.0.0 could not parse a negative offset at all, so the default
+        # applies its minute-count reading of the digits to the sign too.
+        (mt940.Options(), -datetime.timedelta(minutes=500), '-0500'),
+        # 1!x sign can be '-' as well (e.g. US banks): -0500 is UTC-5.
+        (
+            mt940.Options(timezone_offset=True),
+            -datetime.timedelta(hours=5),
+            '-300',
+        ),
+    ],
+)
+def test_date_time_indication_negative_offset(
+    options: mt940.Options,
+    expected_offset: datetime.timedelta,
+    expected_name: str,
+) -> None:
+    transactions = mt940.parse(
+        ':13D:1701191815-0500\n' + _HEADER + _FOOTER, options=options
+    )
     date = transactions.data['date']
-    assert date.utcoffset() == -datetime.timedelta(hours=5)
+    assert date.utcoffset() == expected_offset
+    assert date.tzname() == expected_name
 
 
-def test_transaction_details_long_multiline_not_truncated() -> None:
-    # The old :86: pattern capped the capture at nine 65-char chunks
-    # (~593 chars). Longer details, e.g. German banks packing many ?NN
-    # subfields -- were silently truncated. The cap had already been bumped
-    # once (commit 4575222) for exactly this reason.
-    lines = [f'line {i:02d} ' + 'x' * 57 for i in range(12)]
-    details = '\n'.join(lines)
+_DETAIL_LINES = [f'line {i:02d} ' + 'x' * 57 for i in range(12)]
+
+
+@pytest.mark.parametrize(
+    ('options', 'expected'),
+    [
+        # 5.0.0 captured nine chunks of 65 characters and silently dropped
+        # the rest, e.g. German banks packing many ?NN subfields.
+        (mt940.Options(), '\n'.join(_DETAIL_LINES[:9])),
+        (mt940.Options(unbounded_details=True), '\n'.join(_DETAIL_LINES)),
+    ],
+)
+def test_transaction_details_long_multiline(
+    options: mt940.Options, expected: str
+) -> None:
+    details = '\n'.join(_DETAIL_LINES)
     transactions = mt940.parse(
         _HEADER
         + ':61:2312290101D10,50NMSC\n'
         + ':86:'
         + details
         + '\n'
-        + _FOOTER
+        + _FOOTER,
+        options=options,
     )
-    assert transactions[0].data['transaction_details'] == details
+    assert transactions[0].data['transaction_details'] == expected
 
 
-def test_non_swift_multiline_free_text() -> None:
+@pytest.mark.parametrize(
+    ('options', 'expected_length'),
+    [
+        (mt940.Options(), 585),
+        (mt940.Options(unbounded_details=True), 700),
+    ],
+)
+def test_transaction_details_single_long_line(
+    options: mt940.Options, expected_length: int
+) -> None:
+    tag = mt940.tags.TransactionDetails()
+    transactions = mt940.models.Transactions(options=options)
+    parsed = tag.parse(transactions, 'x' * 700)
+    assert len(parsed['transaction_details'] or '') == expected_length
+
+
+@pytest.mark.parametrize(
+    ('options', 'expected'),
+    [
+        # 5.0.0 turned a line without a sub-tag into a paragraph break once
+        # there was text, dropping the line's content.
+        (mt940.Options(), 'a\n\nb'),
+        (mt940.Options(non_swift_free_text=True), 'a\nfree\nb'),
+    ],
+)
+def test_non_swift_free_text_between_sub_tags(
+    options: mt940.Options, expected: str
+) -> None:
+    tag = mt940.tags.NonSwift()
+    transactions = mt940.models.Transactions(options=options)
+    result = tag(transactions, {'non_swift': '01a\nfree\n02b'})
+    assert result['non_swift_01'] == 'a'
+    assert result['non_swift_02'] == 'b'
+    assert result['non_swift_text'] == expected
+
+
+@pytest.mark.parametrize(
+    ('options', 'expected'),
+    [
+        (mt940.Options(), 'hello\n'),
+        (mt940.Options(non_swift_free_text=True), 'hello\nworld'),
+    ],
+)
+def test_non_swift_multiline_free_text(
+    options: mt940.Options, expected: str
+) -> None:
     # NS content is bank specific ("could be anything"). Multi-line values
     # whose lines do not all start with a two-digit sub-tag used to fail the
-    # NS pattern and abort the whole parse.
-    transactions = mt940.parse(_HEADER + ':NS:hello\nworld\n' + _FOOTER)
+    # NS pattern and abort the whole parse. They parse in both modes now,
+    # the default keeps the 5.0.0 line handling.
+    transactions = mt940.parse(
+        _HEADER + ':NS:hello\nworld\n' + _FOOTER, options=options
+    )
     assert transactions.data['non_swift'] == 'hello\nworld'
-    assert transactions.data['non_swift_text'] == 'hello\nworld'
+    assert transactions.data['non_swift_text'] == expected
 
 
-def test_non_swift_structured_line_followed_by_free_text() -> None:
-    transactions = mt940.parse(_HEADER + ':NS:22foo\nbar\n' + _FOOTER)
+@pytest.mark.parametrize(
+    ('options', 'expected'),
+    [
+        (mt940.Options(), 'foo\n'),
+        (mt940.Options(non_swift_free_text=True), 'foo\nbar'),
+    ],
+)
+def test_non_swift_structured_line_followed_by_free_text(
+    options: mt940.Options, expected: str
+) -> None:
+    transactions = mt940.parse(
+        _HEADER + ':NS:22foo\nbar\n' + _FOOTER, options=options
+    )
     assert transactions.data['non_swift'] == '22foo\nbar'
     assert transactions.data['non_swift_22'] == 'foo'
-    assert transactions.data['non_swift_text'] == 'foo\nbar'
+    assert transactions.data['non_swift_text'] == expected
 
 
-def test_non_swift_blank_lines_collapse() -> None:
+@pytest.mark.parametrize('options', [mt940.Options(), _ALL])
+def test_non_swift_blank_lines_collapse(options: mt940.Options) -> None:
     # Direct tag call: blank lines between content are kept as single
     # paragraph separators in non_swift_text (mt940.parse strips blank
-    # lines before tags ever see them).
+    # lines before tags ever see them). Both modes agree.
     tag = mt940.tags.NonSwift()
     result = tag(
-        mt940.models.Transactions(), {'non_swift': '22foo\n\n\n22bar'}
+        mt940.models.Transactions(options=options),
+        {'non_swift': '22foo\n\n\n22bar'},
     )
     assert result['non_swift_text'] == 'foo\n\nbar'
 
 
-def test_floor_limit_space_indicator_treated_as_absent() -> None:
+_FLOOR_LIMIT_ONLY = (
+    _PREAMBLE
+    + ':34F:EUR 500,00\n'
+    + ':61:0910201020C500,00NTRFNONREF//B\n'
+    + ':86:Example\n'
+)
+
+
+def test_floor_limit_space_indicator_default_keeps_the_space() -> None:
     # Fiducia / Volksbank Ortenau sends ':34F:EUR 999999999999,99' (commit
-    # d36c51b relaxed the regex for it). A blank D/C mark means "applies to
-    # both", like an absent mark -- it must not create a ' _floor_limit' key.
+    # d36c51b relaxed the regex for it). 5.0.0 let the space through into
+    # the key, and since neither d_ nor c_floor_limit exists it found no
+    # statement currency for the transactions either.
+    transactions = mt940.parse(_FLOOR_LIMIT_ONLY)
+    assert str(transactions.data[' _floor_limit']) == '500.00 EUR'
+    assert 'd_floor_limit' not in transactions.data
+    assert transactions.currency is None
+    assert transactions[0].data['amount'].currency is None
+
+
+def test_floor_limit_space_indicator_treated_as_absent() -> None:
+    # A blank D/C mark means "applies to both", like an absent mark, and the
+    # floor limit then also supplies the statement currency.
     transactions = mt940.parse(
-        _PREAMBLE + ':34F:EUR 999999999999,99\n' + _OPENING + _FOOTER
+        _FLOOR_LIMIT_ONLY, options=mt940.Options(floor_limit_blank_mark=True)
     )
     assert ' _floor_limit' not in transactions.data
-    assert str(transactions.data['d_floor_limit']) == '-999999999999.99 EUR'
-    assert str(transactions.data['c_floor_limit']) == '999999999999.99 EUR'
+    assert str(transactions.data['d_floor_limit']) == '-500.00 EUR'
+    assert str(transactions.data['c_floor_limit']) == '500.00 EUR'
+    assert transactions.currency == 'EUR'
+    assert transactions[0].data['amount'].currency == 'EUR'
 
 
-def test_floor_limit_lowercase_indicator_normalized() -> None:
+@pytest.mark.parametrize(
+    ('options', 'expected'),
+    [
+        # 5.0.0 lowercased the key but compared the mark with 'D' only, so
+        # the debit limit came back positive.
+        (mt940.Options(), '10.00 EUR'),
+        (mt940.Options(case_insensitive_marks=True), '-10.00 EUR'),
+    ],
+)
+def test_floor_limit_lowercase_indicator(
+    options: mt940.Options, expected: str
+) -> None:
     # The tag regexes are compiled with re.IGNORECASE, so a lowercase mark
-    # must behave exactly like its uppercase form (debit -> negative).
+    # parses. Whether it signs like its uppercase form is the option.
     transactions = mt940.parse(
-        _PREAMBLE + ':34F:EURd10,00\n' + _OPENING + _FOOTER
+        _PREAMBLE + ':34F:EURd10,00\n' + _OPENING + _FOOTER, options=options
     )
-    assert str(transactions.data['d_floor_limit']) == '-10.00 EUR'
+    assert str(transactions.data['d_floor_limit']) == expected
+
+
+def test_floor_limit_without_a_mark_group_applies_to_both() -> None:
+    # A custom pattern may leave the mark group out entirely. 5.0.0 treated
+    # the resulting None like an absent mark.
+    tag = mt940.tags.FloorLimitIndicator()
+    result = tag(
+        mt940.models.Transactions(),
+        {'currency': 'EUR', 'status': None, 'amount': '5,00'},
+    )
+    assert str(result['d_floor_limit']) == '-5.00 EUR'
+    assert str(result['c_floor_limit']) == '5.00 EUR'
 
 
 class MultilineGroupTag(mt940.tags.Tag):
@@ -116,29 +273,47 @@ def test_unparseable_value_raises_runtime_error() -> None:
         _ = transactions.parse(':20:REF\n:28C:NOTDIGITS\n')
 
 
-def test_statement_rc_reversal_amount_is_negative() -> None:
+@pytest.mark.parametrize(
+    ('options', 'expected'),
+    [
+        # 5.0.0 negated a plain D only, a reversed credit stayed positive.
+        (mt940.Options(), '10.50 EUR'),
+        (mt940.Options(reversal_sign=True), '-10.50 EUR'),
+    ],
+)
+def test_statement_rc_reversal_amount(
+    options: mt940.Options, expected: str
+) -> None:
     transactions = mt940.parse(
-        _HEADER + ':61:2312290101RC10,50NTRFREF//BANK\n' + _FOOTER
+        _HEADER + ':61:2312290101RC10,50NTRFREF//BANK\n' + _FOOTER,
+        options=options,
     )
     data = transactions[0].data
     assert data['status'] == 'RC'
-    assert str(data['amount']) == '-10.50 EUR'
+    assert str(data['amount']) == expected
 
 
-def test_statement_reversal_marks_parse() -> None:
+@pytest.mark.parametrize(
+    ('options', 'expected_rc'),
+    [(mt940.Options(), '10.50 EUR'), (_ALL, '-10.50 EUR')],
+)
+def test_statement_reversal_marks_parse(
+    options: mt940.Options, expected_rc: str
+) -> None:
     # RC/RD marks (2a subfield) parse and are preserved in `status`. RD is
-    # a reversed debit (money back in, positive), RC a reversed credit
-    # (money back out, negative).
+    # a reversed debit (money back in) and stays positive in both modes, RC
+    # a reversed credit (money back out) and negative once opted in.
     transactions = mt940.parse(
         _HEADER
         + ':61:2312290101RD10,50NTRFREF//BANK\n'
         + ':61:2312290101RC10,50NTRFREF//BANK\n'
-        + _FOOTER
+        + _FOOTER,
+        options=options,
     )
     assert transactions[0].data['status'] == 'RD'
     assert str(transactions[0].data['amount']) == '10.50 EUR'
     assert transactions[1].data['status'] == 'RC'
-    assert str(transactions[1].data['amount']) == '-10.50 EUR'
+    assert str(transactions[1].data['amount']) == expected_rc
 
 
 def test_statement_amount_without_decimals() -> None:
@@ -149,16 +324,27 @@ def test_statement_amount_without_decimals() -> None:
     assert str(transactions[0].data['amount']) == '10 EUR'
 
 
-def test_statement_lowercase_debit_mark_is_negative() -> None:
+@pytest.mark.parametrize(
+    ('options', 'expected'),
+    [
+        # 5.0.0 compared the mark with 'D' only, so the debit was silently
+        # stored as positive.
+        (mt940.Options(), '10.50 EUR'),
+        (mt940.Options(case_insensitive_marks=True), '-10.50 EUR'),
+    ],
+)
+def test_statement_lowercase_debit_mark(
+    options: mt940.Options, expected: str
+) -> None:
     # The tag patterns are compiled with re.IGNORECASE, so a lowercase 'd'
-    # debit mark is accepted. Amount must still treat it as a debit and
-    # negate the amount, otherwise a debit is silently stored as positive.
+    # debit mark is accepted and kept as parsed in `status`.
     transactions = mt940.parse(
-        _HEADER + ':61:2312290101d10,50NTRFREF//BANK\n' + _FOOTER
+        _HEADER + ':61:2312290101d10,50NTRFREF//BANK\n' + _FOOTER,
+        options=options,
     )
     data = transactions[0].data
     assert data['status'] == 'd'
-    assert str(data['amount']) == '-10.50 EUR'
+    assert str(data['amount']) == expected
 
 
 def test_statement_second_double_slash_stays_in_bank_reference() -> None:
@@ -187,10 +373,13 @@ def test_balance_on_leap_day() -> None:
     assert balance.date == mt940.models.Date(2024, 2, 29)
 
 
-def test_date_time_indication_without_offset() -> None:
+@pytest.mark.parametrize('options', [mt940.Options(), _ALL])
+def test_date_time_indication_without_offset(options: mt940.Options) -> None:
     # The offset is optional in the pattern. A bare 10-digit :13: must not
-    # crash and yields a naive datetime.
-    transactions = mt940.parse(':13:1701191815\n' + _HEADER + _FOOTER)
+    # crash and yields a naive datetime in both modes.
+    transactions = mt940.parse(
+        ':13:1701191815\n' + _HEADER + _FOOTER, options=options
+    )
     date = transactions.data['date']
     assert date == mt940.models.DateTime(2017, 1, 19, 18, 15)
     assert date.tzinfo is None
@@ -350,11 +539,19 @@ def test_unknown_tag_id_is_skipped() -> None:
     assert 'IGNORED' not in str(transactions.data)
 
 
-def test_tags_of_one_class_are_equal_and_hash_alike() -> None:
-    # CodeQL py/equals-hash-mismatch: Tag hashed on its id without defining
-    # equality. Instances of one tag class are interchangeable.
-    assert mt940.tags.Statement() == mt940.tags.Statement()
-    assert hash(mt940.tags.Statement()) == hash(mt940.tags.Statement())
-    assert mt940.tags.Statement() != mt940.tags.StatementASNB()
-    assert mt940.tags.Statement() != mt940.tags.Statement().id
-    assert len({mt940.tags.Statement(), mt940.tags.Statement()}) == 1
+def test_tags_compare_by_identity() -> None:
+    # 5.0.0 semantics: every instance is its own set member and dictionary
+    # key, while the hash stays id-based so an object hashes like itself.
+    first = mt940.tags.Statement()
+    second = mt940.tags.Statement()
+    assert first == first  # noqa: PLR0124 (identity is the point)
+    assert first != second
+    assert hash(first) == hash(second)
+    assert len({first, second}) == 2
+    assert first != mt940.tags.StatementASNB()
+    assert first != first.id
+
+
+def test_asnb_statement_keeps_its_call_override() -> None:
+    # 5.0.0 defined the pass-through on the class itself, so it stays.
+    assert '__call__' in vars(mt940.tags.StatementASNB)

--- a/ruff.toml
+++ b/ruff.toml
@@ -88,6 +88,10 @@ ignore-decorators = ['typing.overload', 'typing.override']
 [lint.pycodestyle]
 max-line-length = 79
 
+[lint.pylint]
+# parse() takes the source plus five documented knobs.
+max-args = 6
+
 [format]
 line-ending = 'lf'
 indent-style = 'space'


### PR DESCRIPTION
An adversarial comparison of `master` (5.0.0) against `develop` (every fixture in eight input forms, 127 crafted statements, a static API diff, cross-version pickles) found ten silent output changes, three crash fixes and a tail of API and exception-type changes. This applies one rule: 5.0.0 output is the default, every fix is a switch on `mt940.Options`, crash fixes stay unconditional.

**Opt-in switches**, all off by default, `Options.all()` turns them on, the next major release makes them the default: `applicant_iban` (#132), `merge_keeps_values`, `reversal_sign` (#130), `case_insensitive_marks`, `timezone_offset`, `unbounded_details`, `non_swift_free_text`, `floor_limit_blank_mark`, `strip_bom`, `gvc_leading_text`. Documented in the README and the usage guide.

**Restored 5.0.0 semantics**: source handling (anything with `read()` first, file descriptors accepted, `TypeError` for unsupported sources), `Amount` with a missing status, `Balance` with an empty amount, `Transactions.currency` duck typing, `SumAmount` equality, `Tag` identity equality, the instantiable scope marker, `dt` keyword on the tzinfo methods, runtime re-exports of `PreProcessor`, `PostProcessor` and `Processors`, resolvable protocol type hints.

**Kept on purpose**: a missing path-like source raises `FileNotFoundError` instead of a bare `AssertionError`, and inputs that made 5.0.0 raise now parse in every mode.

**Verification**: replaying the audit's 57 fixtures in eight input forms gives byte-identical output to 5.0.0 by default and to the previous develop with `Options.all()`. The goldens pin both modes, with a separate `.all.yml` only for the 17 fixtures the fixes change. Every checker, the tox matrix and 100% coverage pass.