### PR TITLE
Fix the CodeQL findings on the opt-in code

### DIFF
--- a/mt940_tests/test_models.py
+++ b/mt940_tests/test_models.py
@@ -5,17 +5,16 @@ import typing
 import mt940
 import mt940._types
 import pytest
-from mt940 import models
 
 
 def test_model_repr_uses_the_class_name() -> None:
-    assert repr(models.Model()) == '<Model>'
+    assert repr(mt940.models.Model()) == '<Model>'
 
 
 def test_balance_empty_amount_string_is_stored_as_is() -> None:
     # 5.0.0 stored an empty amount string unchanged, so that stays: it is
     # neither coerced to an Amount nor turned into None.
-    balance = models.Balance(amount='', status='C', currency='EUR')
+    balance = mt940.models.Balance(amount='', status='C', currency='EUR')
     assert balance.amount == ''  # noqa: PLC1901 (the exact value matters)
     assert balance.status == 'C'
     assert str(balance) == ' @ None'
@@ -23,7 +22,7 @@ def test_balance_empty_amount_string_is_stored_as_is() -> None:
 
 def test_amount_without_a_status_is_positive() -> None:
     # 5.0.0 compared the mark to 'D' and None simply did not match.
-    amount = models.Amount('1.00', None, 'EUR')
+    amount = mt940.models.Amount('1.00', None, 'EUR')
     assert amount.amount == decimal.Decimal('1.00')
     assert amount.currency == 'EUR'
 
@@ -33,45 +32,49 @@ def test_balance_amount_string_needs_a_status() -> None:
     with pytest.raises(
         ValueError, match='Cannot create Amount without status'
     ):
-        _ = models.Balance(amount='1,00', status=None)
+        _ = mt940.models.Balance(amount='1,00', status=None)
 
 
 def test_default_tags_alias_is_deprecated() -> None:
     with pytest.deprecated_call(match='defaultTags is deprecated'):
-        deprecated = models.Transactions.defaultTags()
-    assert deprecated == models.Transactions.default_tags()
+        deprecated = mt940.models.Transactions.defaultTags()
+    assert deprecated == mt940.models.Transactions.default_tags()
 
 
 def test_equal_amounts_hash_alike() -> None:
-    comma = models.Amount('1,00', 'C', 'EUR')
-    dot = models.Amount('1.00', 'C', 'EUR')
+    comma = mt940.models.Amount('1,00', 'C', 'EUR')
+    dot = mt940.models.Amount('1.00', 'C', 'EUR')
     assert comma == dot
     assert hash(comma) == hash(dot)
     assert len({comma, dot}) == 1
 
 
 def test_equal_balances_hash_alike() -> None:
-    date = models.Date(2024, 1, 1)
-    first = models.Balance('C', models.Amount('1,00', 'C', 'EUR'), date)
-    second = models.Balance('C', '1.00', date, currency='EUR')
+    date = mt940.models.Date(2024, 1, 1)
+    first = mt940.models.Balance(
+        'C', mt940.models.Amount('1,00', 'C', 'EUR'), date
+    )
+    second = mt940.models.Balance('C', '1.00', date, currency='EUR')
     assert first == second
     assert hash(first) == hash(second)
     assert len({first, second}) == 1
 
 
 def test_currency_is_none_without_a_signed_amount() -> None:
-    transactions = models.Transactions()
+    transactions = mt940.models.Transactions()
     assert transactions.currency is None
 
     # A balance that parsed without an amount carries no currency either,
     # and neither does one holding the empty amount string.
-    transactions.data['final_opening_balance'] = models.Balance(status='C')
+    transactions.data['final_opening_balance'] = mt940.models.Balance(
+        status='C'
+    )
     assert transactions.currency is None
-    transactions.data['final_opening_balance'] = models.Balance('C', '')
+    transactions.data['final_opening_balance'] = mt940.models.Balance('C', '')
     assert transactions.currency is None
 
-    transactions.data['final_opening_balance'] = models.Balance(
-        'C', models.Amount('1,00', 'C', 'USD')
+    transactions.data['final_opening_balance'] = mt940.models.Balance(
+        'C', mt940.models.Amount('1,00', 'C', 'USD')
     )
     assert transactions.currency == 'USD'
 
@@ -86,18 +89,20 @@ class _DuckWithAmount:
     """Something that is not a Balance but wraps an object with a currency."""
 
     def __init__(self) -> None:
-        self.amount: models.Amount = models.Amount('1,00', 'C', 'JPY')
+        self.amount: mt940.models.Amount = mt940.models.Amount(
+            '1,00', 'C', 'JPY'
+        )
 
 
 class _DuckWithoutCurrency:
     """Something whose currency attribute is present but not a string."""
 
     currency: None = None
-    amount: models.Amount = models.Amount('1,00', 'C', 'JPY')
+    amount: mt940.models.Amount = mt940.models.Amount('1,00', 'C', 'JPY')
 
 
 def _currency_with(balance: object) -> str | None:
-    transactions = models.Transactions()
+    transactions = mt940.models.Transactions()
     transactions.data['opening_balance'] = balance
     return transactions.currency
 
@@ -122,8 +127,10 @@ def test_currency_duck_types_like_5_0_0(
 
 
 def test_currency_from_a_bare_floor_limit() -> None:
-    transactions = models.Transactions()
-    transactions.data['c_floor_limit'] = models.Amount('1,00', 'C', 'CHF')
+    transactions = mt940.models.Transactions()
+    transactions.data['c_floor_limit'] = mt940.models.Amount(
+        '1,00', 'C', 'CHF'
+    )
     assert transactions.currency == 'CHF'
 
 
@@ -131,11 +138,15 @@ def test_scope_marker_is_a_subclass_of_both_and_instantiable() -> None:
     # TransactionsAndTransaction exists for issubclass checks on Tag.scope.
     # Building one worked in 5.0.0 (it runs Transactions.__init__), so it
     # still does.
-    assert issubclass(models.TransactionsAndTransaction, models.Transactions)
-    assert issubclass(models.TransactionsAndTransaction, models.Transaction)
-    marker = models.TransactionsAndTransaction()
-    assert isinstance(marker, models.Transactions)
-    assert isinstance(marker, models.Transaction)
+    assert issubclass(
+        mt940.models.TransactionsAndTransaction, mt940.models.Transactions
+    )
+    assert issubclass(
+        mt940.models.TransactionsAndTransaction, mt940.models.Transaction
+    )
+    marker = mt940.models.TransactionsAndTransaction()
+    assert isinstance(marker, mt940.models.Transactions)
+    assert isinstance(marker, mt940.models.Transaction)
     assert len(marker) == 0
 
 
@@ -144,11 +155,11 @@ def test_sum_amount_equality_ignores_the_entry_count() -> None:
     # Amount of the same value is equal and so are two totals over a
     # different number of entries. The explicit __eq__ keeps CodeQL's
     # py/missing-equals satisfied without changing that.
-    two = models.SumAmount('10,00', 'C', 'EUR', number=2)
-    also_two = models.SumAmount('10,00', 'C', 'EUR', number=2)
-    three = models.SumAmount('10,00', 'C', 'EUR', number=3)
-    plain = models.Amount('10,00', 'C', 'EUR')
-    other = models.SumAmount('11,00', 'C', 'EUR', number=2)
+    two = mt940.models.SumAmount('10,00', 'C', 'EUR', number=2)
+    also_two = mt940.models.SumAmount('10,00', 'C', 'EUR', number=2)
+    three = mt940.models.SumAmount('10,00', 'C', 'EUR', number=3)
+    plain = mt940.models.Amount('10,00', 'C', 'EUR')
+    other = mt940.models.SumAmount('11,00', 'C', 'EUR', number=2)
 
     assert two == also_two
     assert two == three
@@ -161,7 +172,7 @@ def test_sum_amount_equality_ignores_the_entry_count() -> None:
 
 def test_fixed_offset_methods_accept_the_dt_keyword() -> None:
     # The tzinfo methods took `dt` as a keyword in 5.0.0.
-    offset = models.FixedOffset(60, 'CET')
+    offset = mt940.models.FixedOffset(60, 'CET')
     assert offset.utcoffset(dt=None) == datetime.timedelta(minutes=60)
     assert offset.dst(dt=None) == datetime.timedelta(0)
     assert offset.tzname(dt=None) == 'CET'
@@ -169,7 +180,7 @@ def test_fixed_offset_methods_accept_the_dt_keyword() -> None:
 
 def test_processors_alias_is_exported_at_runtime() -> None:
     # 5.0.0 exposed the Processors alias on mt940.models.
-    assert models.Processors is mt940._types.Processors
+    assert mt940.models.Processors is mt940._types.Processors
 
 
 def test_processor_protocol_hints_resolve_at_runtime() -> None:
@@ -183,9 +194,9 @@ def test_processor_protocol_hints_resolve_at_runtime() -> None:
 
 def test_unpickling_state_without_options_gets_the_defaults() -> None:
     # Pickles written by 5.0.0 carry no options attribute.
-    state = models.Transactions().__getstate__()
+    state = mt940.models.Transactions().__getstate__()
     del state['options']
-    restored = models.Transactions.__new__(models.Transactions)
+    restored = mt940.models.Transactions.__new__(mt940.models.Transactions)
     restored.__setstate__(state)
     assert restored.options == mt940.Options()
 
@@ -210,5 +221,5 @@ def test_amount_signing_follows_the_options(
     # 5.0.0 negated a plain D only. Reversals and lowercase marks are signed
     # on request, and a reversed debit stays positive whatever is switched
     # on.
-    amount = models.Amount('1.00', status, 'EUR', options=options)
+    amount = mt940.models.Amount('1.00', status, 'EUR', options=options)
     assert amount.amount == sign * decimal.Decimal('1.00')

--- a/mt940_tests/test_parse.py
+++ b/mt940_tests/test_parse.py
@@ -1,3 +1,4 @@
+import contextlib
 import os
 import pathlib
 import pickle
@@ -117,10 +118,16 @@ def test_file_descriptor_is_read_and_closed() -> None:
     # 5.0.0 accepted an int through os.path.isfile and open(), which closes
     # the descriptor on the way out.
     fd = os.open(_ING, os.O_RDONLY)
-    transactions = mt940.parse(fd)
+    try:
+        transactions = mt940.parse(fd)
+        with pytest.raises(OSError, match='Bad file descriptor'):
+            _ = os.fstat(fd)
+    finally:
+        # parse() closed the descriptor, this only matters when the
+        # assertion above fails.
+        with contextlib.suppress(OSError):
+            os.close(fd)
     assert len(transactions) == len(mt940.parse(_ING))
-    with pytest.raises(OSError, match='Bad file descriptor'):
-        _ = os.fstat(fd)
 
 
 @pytest.mark.parametrize(

--- a/mt940_tests/test_tags.py
+++ b/mt940_tests/test_tags.py
@@ -543,8 +543,9 @@ def test_tags_compare_by_identity() -> None:
     # 5.0.0 semantics: every instance is its own set member and dictionary
     # key, while the hash stays id-based so an object hashes like itself.
     first = mt940.tags.Statement()
+    same = first
     second = mt940.tags.Statement()
-    assert first == first  # noqa: PLR0124 (identity is the point)
+    assert first == same
     assert first != second
     assert hash(first) == hash(second)
     assert len({first, second}) == 2


### PR DESCRIPTION
Three of the four findings from the first develop scan after #136: a test file descriptor without a closing safety net, one more test module with mixed import forms, and a self-comparison in the tag identity test. The fourth, the `...` body of the source Protocol stub, is dismissed as a false positive like the overload stubs.