### PR TITLE
Materialize transaction_boundary once in parse_statements

### DIFF
--- a/mt940/parser.py
+++ b/mt940/parser.py
@@ -217,6 +217,12 @@ def parse_statements(
     """
     data = _read(src, encoding, strip_bom=(options or Options()).strip_bom)
     statements: list[Transactions] = []
+    # Each statement consumes the boundaries when constructing its collection.
+    # Materialize one-shot iterables once; keep bare strings as a single slug.
+    if transaction_boundary is not None and not isinstance(
+        transaction_boundary, str
+    ):
+        transaction_boundary = tuple(transaction_boundary)
     for block in re.split(r'(?m)^(?=:20:)', data):
         if not block.strip().startswith(':20:'):
             # Drop any leading header / empty chunk before the first :20:.

--- a/mt940_tests/test_issues/test_issue107_statements.py
+++ b/mt940_tests/test_issues/test_issue107_statements.py
@@ -7,7 +7,10 @@ splits the input on ``:20:`` boundaries so each statement block keeps its own
 balances. The default ``parse()`` behaviour is unchanged.
 """
 
+from collections.abc import Iterable
+
 import mt940
+import pytest
 
 MULTI_BLOCK = """:20:REF1
 :25:ACC1
@@ -88,4 +91,32 @@ def test_kwargs_passed_through_to_each_block() -> None:
     assert (
         transaction.data['customer_reference']
         == 'BIPI-dvT1FzfMqvzF5HaU4oetlH7SGRkonU'
+    )
+
+
+@pytest.mark.parametrize(
+    'boundary',
+    [
+        ('transaction_details',),
+        'transaction_details',
+        iter(('transaction_details',)),
+    ],
+    ids=['tuple', 'string', 'iterator'],
+)
+def test_boundary_iterable_applies_to_every_statement(
+    boundary: Iterable[str],
+) -> None:
+    block = (
+        ':20:REF\n:25:ACC\n:60F:C200101EUR0,00\n'
+        ':61:2001010101C5,00NTRFa//b\n'
+        ':86:116?00detail\n:62F:C200101EUR5,00\n'
+    )
+    statements = mt940.parse_statements(
+        block + block, transaction_boundary=boundary
+    )
+
+    assert [len(statement) for statement in statements] == [2, 2]
+    assert all(
+        statement.transaction_boundary == frozenset({'transaction_details'})
+        for statement in statements
     )


### PR DESCRIPTION
## Problem

`parse_statements()` splits the file on `:20:` and passes `transaction_boundary` to a new `Transactions` for each block. Each `Transactions` consumes the iterable to build its `frozenset`. When the caller passes a one-shot iterable (generator, `iter(...)`, `map(...)`), the first statement uses it and every later statement gets an empty boundary, so transactions in the same file are grouped inconsistently and nothing signals the problem.

```python
mt940.parse_statements(data, transaction_boundary=iter(('transaction_details',)))
# statement 1: boundary = {'transaction_details'}
# statement 2+: boundary = frozenset()
```

## Fix

Convert non-string iterables to a tuple once before the loop, so each statement receives the same boundary. Bare strings are passed through unchanged so a single slug keeps working.

## Tests

- Added `test_boundary_iterable_applies_to_every_statement` parametrized over tuple, string and iterator inputs. The iterator case failed before the change and passes after it.
- `ruff check`, `ruff format --check`, `mypy mt940` and the full `pytest` run (405 passed, 1 xfail) are clean locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PtpcFAThUxrGAyCyxiiEC5
