### PR TITLE
fix: key the CI concurrency group on the ref, not the commit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,8 +12,11 @@ on:
 permissions:
   contents: read
 
+# Keyed on the ref, not the commit. A release pushes the same commit to
+# develop and master at once, and keying on the sha made one run cancel the
+# other, which the branch badge then reports as failing.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 env:


### PR DESCRIPTION
The CI badge in the README showed failing after the 5.1.0 release.

Root cause: the ci.yml concurrency group was keyed on the commit sha. A release pushes the same commit to develop and master at once, so the master run cancelled the develop run, and GitHub renders a cancelled run as failing on the branch badge.

Fix: key the group on the ref, matching publish.yml. Pushes of the same commit to different branches now run independently, and a new push to the same branch still cancels the stale run.

Verified with actionlint and the zizmor tox env. The cancelled develop run was re-run separately to repair the badge right away.